### PR TITLE
Add barebones functionality to fetch data from a dashboard

### DIFF
--- a/pydash/Pipfile
+++ b/pydash/Pipfile
@@ -13,6 +13,8 @@ flask-login = "*"
 multi-indexed-collection = "*"
 zeo = "*"
 flask-restplus = "*"
+pyjwt = "*"
+requests = "*"
 
 
 [dev-packages]

--- a/pydash/Pipfile.lock
+++ b/pydash/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bca1a25f1da4d2a4f7dc3b90848a89a7e5c023acfd2d514c3d264ab3dd035b7c"
+            "sha256": "c1f46527ed4a8226b741d27a7ca3852d50bba183c9df546baf16f21b481eecad"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -69,6 +69,20 @@
             ],
             "version": "==4.4.1"
         },
+        "certifi": {
+            "hashes": [
+                "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
+                "sha256:edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
+            ],
+            "version": "==2018.1.18"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
         "click": {
             "hashes": [
                 "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d",
@@ -102,6 +116,13 @@
                 "sha256:d9a9e366b32dcbb98ef17228e76be15702cd2600675668bca23f63a7947fd5ac"
             ],
             "version": "==0.14.2"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
+                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
+            ],
+            "version": "==2.6"
         },
         "itsdangerous": {
             "hashes": [
@@ -169,6 +190,13 @@
             ],
             "version": "==4.2.4.2"
         },
+        "pyjwt": {
+            "hashes": [
+                "sha256:bca523ef95586d3a8a5be2da766fe6f82754acba27689c984e28e77a12174593",
+                "sha256:dacba5786fe3bf1a0ae8673874e29f9ac497860955c501289c63b15d3daae63a"
+            ],
+            "version": "==1.6.1"
+        },
         "pytz": {
             "hashes": [
                 "sha256:07edfc3d4d2705a20a6e99d97f0c4b61c800b8232dc1c04d87e8554f130148dd",
@@ -183,6 +211,13 @@
             ],
             "version": "==2018.3"
         },
+        "requests": {
+            "hashes": [
+                "sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b",
+                "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
+            ],
+            "version": "==2.18.4"
+        },
         "six": {
             "hashes": [
                 "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
@@ -196,6 +231,13 @@
                 "sha256:714d6883dfd5f41f454afce716c58bb59ba10af3d23562b5be781cbbd6fb5100"
             ],
             "version": "==2.2.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
+                "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+            ],
+            "version": "==1.22"
         },
         "werkzeug": {
             "hashes": [

--- a/pydash/pydash_app/dashboard/fetch.py
+++ b/pydash/pydash_app/dashboard/fetch.py
@@ -3,14 +3,20 @@ import jwt
 import json
 
 
+DETAILS_ENDPOINT = 0
+RULES_ENDPOINT = 1
+DATA_ENDPOINT = 2
+
+
 def get_details(dashboard_url):
     """
     Get details from a deployed flask-monitoring-dashboard
     :param dashboard_url: The base URL for the deployed dashboard, without trailing slash
     :return: A dict containing details from the dashboard, or None if the request was unsuccessful
     """
-    endpoint = 'get_json_details'
-    response = requests.get(f'{dashboard_url}/{endpoint}')
+    endpoint = _endpoint_name(DETAILS_ENDPOINT)
+
+    response = requests.get(f'{dashboard_url}/{_endpoint_name()}')
 
     if response.status_code != 200:
         return None
@@ -25,7 +31,8 @@ def get_monitor_rules(dashboard_url, dashboard_token):
     :param dashboard_token: The secret token for the dashboard, used to decode the Json Web Token response
     :return: A dict containing monitor rules of the dashboard, or None if the request was unsuccessful
     """
-    endpoint = 'get_json_monitor_rules'
+    endpoint = _endpoint_name(RULES_ENDPOINT)
+
     response = requests.get(f'{dashboard_url}/{endpoint}')
 
     if response.status_code != 200:
@@ -42,7 +49,8 @@ def get_data(dashboard_url, dashboard_token, time_from=None):
     :param time_from: An optional timestamp string indicating only data since that timestamp should be included
     :return: A dict containing all monitoring data or data since a given timestamp
     """
-    endpoint = 'get_json_data'
+    endpoint = _endpoint_name(DATA_ENDPOINT)
+
     url = f'{dashboard_url}/{endpoint}'
     if time_from is not None:
         url = f'{url}/{time_from}'
@@ -53,6 +61,15 @@ def get_data(dashboard_url, dashboard_token, time_from=None):
         return None
 
     return _decode_jwt(response.text, dashboard_token)
+
+
+def _endpoint_name(endpoint):
+    names = [
+        'get_json_details',
+        'get_json_monitor_rules',
+        'get_json_data'
+    ]
+    return names[endpoint]
 
 
 def _decode_jwt(payload, token):

--- a/pydash/pydash_app/dashboard/fetch.py
+++ b/pydash/pydash_app/dashboard/fetch.py
@@ -31,7 +31,7 @@ def get_monitor_rules(dashboard_url, dashboard_token):
     if response.status_code != 200:
         return None
 
-    return __decode_jwt(response.text, dashboard_token)
+    return _decode_jwt(response.text, dashboard_token)
 
 
 def get_data(dashboard_url, dashboard_token, time_from=None):
@@ -52,10 +52,10 @@ def get_data(dashboard_url, dashboard_token, time_from=None):
     if response.status_code != 200:
         return None
 
-    return __decode_jwt(response.text, dashboard_token)
+    return _decode_jwt(response.text, dashboard_token)
 
 
-def __decode_jwt(payload, token):
+def _decode_jwt(payload, token):
     """
     Decode a Json Web Token response from the python-monitoring-dashboard JSON data API
     :param payload: The JWT payload to decode

--- a/pydash/pydash_app/dashboard/fetch.py
+++ b/pydash/pydash_app/dashboard/fetch.py
@@ -16,7 +16,7 @@ def get_details(dashboard_url):
     """
     endpoint = _endpoint_name(DETAILS_ENDPOINT)
 
-    response = requests.get(f'{dashboard_url}/{_endpoint_name()}')
+    response = requests.get(f'{dashboard_url}/{endpoint}')
 
     if response.status_code != 200:
         return None

--- a/pydash/pydash_app/dashboard/fetch.py
+++ b/pydash/pydash_app/dashboard/fetch.py
@@ -1,0 +1,66 @@
+import requests
+import jwt
+import json
+
+
+def get_details(dashboard_url):
+    """
+    Get details from a deployed flask-monitoring-dashboard
+    :param dashboard_url: The base URL for the deployed dashboard, without trailing slash
+    :return: A dict containing details from the dashboard, or None if the request was unsuccessful
+    """
+    endpoint = 'get_json_details'
+    response = requests.get(f'{dashboard_url}/{endpoint}')
+
+    if response.status_code != 200:
+        return None
+
+    return json.loads(response.text)
+
+
+def get_monitor_rules(dashboard_url, dashboard_token):
+    """
+    Get monitor rules from a deployed flask-monitoring-dashboard
+    :param dashboard_url: The base URL for the deployed dashboard, without trailing slash
+    :param dashboard_token: The secret token for the dashboard, used to decode the Json Web Token response
+    :return: A dict containing monitor rules of the dashboard, or None if the request was unsuccessful
+    """
+    endpoint = 'get_json_monitor_rules'
+    response = requests.get(f'{dashboard_url}/{endpoint}')
+
+    if response.status_code != 200:
+        return None
+
+    return __decode_jwt(response.text, dashboard_token)
+
+
+def get_data(dashboard_url, dashboard_token, time_from=None):
+    """
+    Get data from a deployed flask-monitoring-dashboard
+    :param dashboard_url: The base URL for the deployed dashboard, without trailing slash
+    :param dashboard_token: The secret token for the dashboard, used to decode the Json Web Token response
+    :param time_from: An optional timestamp string indicating only data since that timestamp should be included
+    :return: A dict containing all monitoring data or data since a given timestamp
+    """
+    endpoint = 'get_json_data'
+    url = f'{dashboard_url}/{endpoint}'
+    if time_from is not None:
+        url = f'{url}/{time_from}'
+
+    response = requests.get(url)
+
+    if response.status_code != 200:
+        return None
+
+    return __decode_jwt(response.text, dashboard_token)
+
+
+def __decode_jwt(payload, token):
+    """
+    Decode a Json Web Token response from the python-monitoring-dashboard JSON data API
+    :param payload: The JWT payload to decode
+    :param token: The secret token for the dashboard
+    :return: A dict containing the data from the payload
+    """
+    message = jwt.decode(payload, token, algorithms=['HS256'])
+    return json.loads(message['data'])


### PR DESCRIPTION
The `pydash_app.dashboard.fetch` module (open to renaming this) wraps the functionality of the `flask-monitoring-dashboard` JSON data API by providing the following functions:
- `get_details(url)` to get some details on the dashboard at `url` such as version
- `get_monitor_rules(url, token)` to return monitoring rules for the dashboard
- `get_data(url, token, [time_from])` to retrieve the actual monitoring data, optionally getting data since a given timestamp