### PR TITLE
Backend/data aggregation

### DIFF
--- a/pydash/pydash_app/dashboard/aggregator.py
+++ b/pydash/pydash_app/dashboard/aggregator.py
@@ -21,7 +21,7 @@ class Aggregator(persistent.Persistent):
         self.total_execution_time = 0
 
         self.average_execution_time = None
-        
+
         self.visits_per_day = defaultdict(lambda: 0)
         self.visits_per_ip = defaultdict(lambda: 0)
 

--- a/pydash/pydash_app/dashboard/aggregator.py
+++ b/pydash/pydash_app/dashboard/aggregator.py
@@ -1,6 +1,8 @@
 from collections import defaultdict
+import datetime
 
 import persistent
+
 
 
 class Aggregator(persistent.Persistent):
@@ -9,13 +11,13 @@ class Aggregator(persistent.Persistent):
     This data is updated every time a new endpoint call is added.
     """
 
-    def __init__(self, endpoint_calls):
+    def __init__(self, endpoint_calls=[]):
         """
         Constructor
         :param endpoint_calls: List of endpoint calls to keep track of
         """
 
-        self._endpoint_calls = endpoint_calls
+        self._endpoint_calls = list(endpoint_calls)
 
         self.total_visits = 0
         self.total_execution_time = 0
@@ -25,23 +27,38 @@ class Aggregator(persistent.Persistent):
         self.visits_per_day = defaultdict(lambda: 0)
         self.visits_per_ip = defaultdict(lambda: 0)
 
+        self.unique_visitors_all_time_set = set()
+        self.unique_visitors_per_day_set = defaultdict(lambda: set())
+
     def add_endpoint_call(self, endpoint_call):
         """
         Add an endpoint call and update aggregated data
         :param endpoint_call: `EndpointCall` instance to add
         """
 
-        # precondition: the endpoint call has been added to the list of endpoint calls already
+        self._endpoint_calls.append(endpoint_call)
 
         self.total_visits += 1
         self.total_execution_time += endpoint_call.execution_time
 
         self.average_execution_time = self.total_execution_time / len(self._endpoint_calls)
 
-        day = endpoint_call.time.strftime('%Y-%m-%d')
-        self.visits_per_day[day] += 1
+        # day = endpoint_call.time.strftime('%Y-%m-%d')
+        date = endpoint_call.time.date()
+        self.visits_per_day[date] += 1
 
         self.visits_per_ip[endpoint_call.ip] += 1
+
+        self.unique_visitors_all_time_set.add(endpoint_call.ip)
+        self.unique_visitors_per_day_set[date].add(endpoint_call.ip)
+
+    @property
+    def unique_visitors_all_time(self):
+        return len(self.unique_visitors_all_time_set)
+
+    @property
+    def unique_visitors_per_day(self):
+        return {k: len(v) for k, v in self.unique_visitors_per_day_set.items()}
 
     def as_dict(self):
         """
@@ -49,10 +66,17 @@ class Aggregator(persistent.Persistent):
         :return: A dict containing several aggregated data points
         """
 
+        def date_dict(dict):
+            # JS expects dates in the ISO 8601 Date format (example: 2018-03)
+            return {k.strftime("%Y-%m-%d"): v for (k, v) in dict.items()}
+
         return {
             'total_visits': self.total_visits,
             'total_execution_time': self.total_execution_time,
             'average_execution_time': self.average_execution_time,
-            'visits_per_day': dict(self.visits_per_day),
-            'visits_per_ip': dict(self.visits_per_ip)
+            'visits_per_day': date_dict(self.visits_per_day),
+            'visits_per_ip': dict(self.visits_per_ip),
+            'unique_visitors': self.unique_visitors_all_time,
+            'unique_visitors_per_day': date_dict(self.unique_visitors_per_day)
         }
+

--- a/pydash/pydash_app/dashboard/aggregator.py
+++ b/pydash/pydash_app/dashboard/aggregator.py
@@ -18,6 +18,10 @@ class Aggregator(persistent.Persistent):
         self.total_visits = 0
         self.total_execution_time = 0
 
+        self.average_execution_time = None
+
+        self.visits_per_day = {}
+
     def add_endpoint_call(self, endpoint_call):
         """
         Add an endpoint call and update aggregated data
@@ -29,6 +33,15 @@ class Aggregator(persistent.Persistent):
         self.total_visits += 1
         self.total_execution_time += endpoint_call.execution_time
 
+        self.average_execution_time = self.total_execution_time / len(self._endpoint_calls)
+
+        day = endpoint_call.time.strftime('%Y-%m-%d')
+
+        if day in self.visits_per_day:
+            self.visits_per_day[day] += 1
+        else:
+            self.visits_per_day[day] = 1
+
     def as_dict(self):
         """
         Get aggregated data in a dict
@@ -38,4 +51,6 @@ class Aggregator(persistent.Persistent):
         return {
             'total_visits': self.total_visits,
             'total_execution_time': self.total_execution_time,
+            'average_execution_time': self.average_execution_time,
+            'visits_per_day': self.visits_per_day
         }

--- a/pydash/pydash_app/dashboard/aggregator.py
+++ b/pydash/pydash_app/dashboard/aggregator.py
@@ -21,6 +21,7 @@ class Aggregator(persistent.Persistent):
         self.average_execution_time = None
 
         self.visits_per_day = {}
+        self.visits_per_ip = {}
 
     def add_endpoint_call(self, endpoint_call):
         """
@@ -36,11 +37,16 @@ class Aggregator(persistent.Persistent):
         self.average_execution_time = self.total_execution_time / len(self._endpoint_calls)
 
         day = endpoint_call.time.strftime('%Y-%m-%d')
-
         if day in self.visits_per_day:
             self.visits_per_day[day] += 1
         else:
             self.visits_per_day[day] = 1
+
+        ip = endpoint_call.ip
+        if ip in self.visits_per_ip:
+            self.visits_per_ip[ip] += 1
+        else:
+            self.visits_per_ip[ip] = 1
 
     def as_dict(self):
         """
@@ -52,5 +58,6 @@ class Aggregator(persistent.Persistent):
             'total_visits': self.total_visits,
             'total_execution_time': self.total_execution_time,
             'average_execution_time': self.average_execution_time,
-            'visits_per_day': self.visits_per_day
+            'visits_per_day': self.visits_per_day,
+            'visits_per_ip': self.visits_per_ip
         }

--- a/pydash/pydash_app/dashboard/aggregator.py
+++ b/pydash/pydash_app/dashboard/aggregator.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 import persistent
 
 
@@ -19,9 +21,9 @@ class Aggregator(persistent.Persistent):
         self.total_execution_time = 0
 
         self.average_execution_time = None
-
-        self.visits_per_day = {}
-        self.visits_per_ip = {}
+        
+        self.visits_per_day = defaultdict(lambda: 0)
+        self.visits_per_ip = defaultdict(lambda: 0)
 
     def add_endpoint_call(self, endpoint_call):
         """
@@ -37,16 +39,9 @@ class Aggregator(persistent.Persistent):
         self.average_execution_time = self.total_execution_time / len(self._endpoint_calls)
 
         day = endpoint_call.time.strftime('%Y-%m-%d')
-        if day in self.visits_per_day:
-            self.visits_per_day[day] += 1
-        else:
-            self.visits_per_day[day] = 1
+        self.visits_per_day[day] += 1
 
-        ip = endpoint_call.ip
-        if ip in self.visits_per_ip:
-            self.visits_per_ip[ip] += 1
-        else:
-            self.visits_per_ip[ip] = 1
+        self.visits_per_ip[endpoint_call.ip] += 1
 
     def as_dict(self):
         """
@@ -58,6 +53,6 @@ class Aggregator(persistent.Persistent):
             'total_visits': self.total_visits,
             'total_execution_time': self.total_execution_time,
             'average_execution_time': self.average_execution_time,
-            'visits_per_day': self.visits_per_day,
-            'visits_per_ip': self.visits_per_ip
+            'visits_per_day': dict(self.visits_per_day),
+            'visits_per_ip': dict(self.visits_per_ip)
         }

--- a/pydash/pydash_app/dashboard/aggregator.py
+++ b/pydash/pydash_app/dashboard/aggregator.py
@@ -1,0 +1,41 @@
+import persistent
+
+
+class Aggregator(persistent.Persistent):
+    """
+    Maintains aggregate data for either a dashboard or a single endpoint.
+    This data is updated every time a new endpoint call is added.
+    """
+
+    def __init__(self, endpoint_calls):
+        """
+        Constructor
+        :param endpoint_calls: List of endpoint calls to keep track of
+        """
+
+        self._endpoint_calls = endpoint_calls
+
+        self.total_visits = 0
+        self.total_execution_time = 0
+
+    def add_endpoint_call(self, endpoint_call):
+        """
+        Add an endpoint call and update aggregated data
+        :param endpoint_call: `EndpointCall` instance to add
+        """
+
+        # precondition: the endpoint call has been added to the list of endpoint calls already
+
+        self.total_visits += 1
+        self.total_execution_time += endpoint_call.execution_time
+
+    def as_dict(self):
+        """
+        Get aggregated data in a dict
+        :return: A dict containing several aggregated data points
+        """
+
+        return {
+            'total_visits': self.total_visits,
+            'total_execution_time': self.total_execution_time,
+        }

--- a/pydash/pydash_app/dashboard/aggregator.py
+++ b/pydash/pydash_app/dashboard/aggregator.py
@@ -4,7 +4,6 @@ import datetime
 import persistent
 
 
-
 class Aggregator(persistent.Persistent):
     """
     Maintains aggregate data for either a dashboard or a single endpoint.

--- a/pydash/pydash_app/dashboard/dashboard.py
+++ b/pydash/pydash_app/dashboard/dashboard.py
@@ -62,6 +62,12 @@ class Dashboard(persistent.Persistent):
         """
         self._endpoint_calls.append(endpoint_call)
         self._aggregator.add_endpoint_call(endpoint_call)
+        
+        # Quick and dirty fix to add endpoint call to endpoint
+        for endpoint in self.endpoints:
+            if endpoint.name == endpoint_call.endpoint:
+                endpoint.add_call(endpoint_call)
+                break
 
     def get_aggregated_data(self):
         """

--- a/pydash/pydash_app/dashboard/dashboard.py
+++ b/pydash/pydash_app/dashboard/dashboard.py
@@ -5,6 +5,30 @@ import persistent
 from .aggregator import Aggregator
 
 
+"""
+
+Example testing code:
+
+from pydash_app.dashboard.dashboard import Dashboard
+from pydash_app.dashboard.endpoint_call import EndpointCall
+import uuid
+from datetime import datetime, timedelta
+d = Dashboard("http://foo.io", str(uuid.uuid4()))
+
+ec1 = EndpointCall("foo", 0.5, datetime.now(), 0.1, "None", "127.0.0.1")
+ec2 = EndpointCall("foo", 0.1, datetime.now(), 0.1, "None", "127.0.0.2")
+ec3 = EndpointCall("bar", 0.2, datetime.now(), 0.1, "None", "127.0.0.1")
+ec4 = EndpointCall("bar", 0.2, datetime.now() - timedelta(days=1), 0.1, "None", "127.0.0.1")
+ec5 = EndpointCall("bar", 0.2, datetime.now() - timedelta(days=2), 0.1, "None", "127.0.0.1")
+d.add_endpoint_call(ec1)
+d.add_endpoint_call(ec2)
+d.add_endpoint_call(ec3)
+d.add_endpoint_call(ec4)
+d.add_endpoint_call(ec5)
+d.aggregated_data()
+"""
+
+
 class Dashboard(persistent.Persistent):
     """
     The Dashboard entity knows about:

--- a/pydash/pydash_app/dashboard/dashboard.py
+++ b/pydash/pydash_app/dashboard/dashboard.py
@@ -59,14 +59,14 @@ class Dashboard(persistent.Persistent):
         """
         self._endpoint_calls.append(endpoint_call)
         self._aggregator.add_endpoint_call(endpoint_call)
-        
+
         # Quick and dirty fix to add endpoint call to endpoint
         for endpoint in self.endpoints:
             if endpoint.name == endpoint_call.endpoint:
                 endpoint.add_call(endpoint_call)
                 break
 
-    def get_aggregated_data(self):
+    def aggregated_data(self):
         """
         Returns aggregated data on this dashboard.
         :return: A dict containing aggregated data points.

--- a/pydash/pydash_app/dashboard/dashboard.py
+++ b/pydash/pydash_app/dashboard/dashboard.py
@@ -50,10 +50,7 @@ class Dashboard(persistent.Persistent):
         """
         # TODO: perhaps remove all relevant endpoint calls from endpoint_calls? Discuss with team.
         # TODO: THIS IS POST-MVP
-        try:
-            self.endpoints.remove(endpoint)
-        except ValueError:
-            raise
+        self.endpoints.remove(endpoint)
 
     def add_endpoint_call(self, endpoint_call):
         """

--- a/pydash/pydash_app/dashboard/dashboard.py
+++ b/pydash/pydash_app/dashboard/dashboard.py
@@ -63,6 +63,13 @@ class Dashboard(persistent.Persistent):
         self._endpoint_calls.append(endpoint_call)
         self._aggregator.add_endpoint_call(endpoint_call)
 
+    def get_aggregated_data(self):
+        """
+        Returns aggregated data on this dashboard.
+        :return: A dict containing aggregated data points.
+        """
+        return self._aggregator.as_dict()
+
     # Required because `multi_indexed_collection` puts dashboards in a set,
     #  that needs to order its keys for fast lookup.
     # Because the IDs are unchanging integer values, use that.

--- a/pydash/pydash_app/dashboard/endpoint.py
+++ b/pydash/pydash_app/dashboard/endpoint.py
@@ -51,7 +51,7 @@ class Endpoint(persistent.Persistent):
     def set_monitored(self, is_monitored):
         self.is_monitored = is_monitored
 
-    def get_aggregated_data(self):
+    def aggregated_data(self):
         """
         Get aggregated data on this endpoint.
         :return: A dict containing aggregated data points.

--- a/pydash/pydash_app/dashboard/endpoint.py
+++ b/pydash/pydash_app/dashboard/endpoint.py
@@ -46,10 +46,7 @@ class Endpoint(persistent.Persistent):
         Raises a ValueError if no such call exists.
         :param call: The endpoint call to remove.
         """
-        try:
-            self._calls.remove(call)
-        except ValueError:
-            raise
+        self._calls.remove(call)
 
     def set_monitored(self, is_monitored):
         self.is_monitored = is_monitored

--- a/pydash/pydash_app/dashboard/endpoint.py
+++ b/pydash/pydash_app/dashboard/endpoint.py
@@ -32,17 +32,17 @@ class Endpoint(persistent.Persistent):
     def get_id(self):
         return str(self.id)
 
-    def add_call(self, call):
+    def add_endpoint_call(self, call):
         """
-        Adds a call to its internal collection of endpoint calls.
+        Adds an EndpointCall to its internal collection of endpoint calls.
         :param call: The endpoint call to add.
         """
         self._calls.append(call)
         self._aggregator.add_endpoint_call(call)
 
-    def remove_call(self, call):
+    def remove_endpoint_call(self, call):
         """
-        Removes a call from this endpoint's internal collection of endpoint calls.
+        Removes an EndpointCall from this endpoint's internal collection of endpoint calls.
         Raises a ValueError if no such call exists.
         :param call: The endpoint call to remove.
         """

--- a/pydash/pydash_app/dashboard/endpoint.py
+++ b/pydash/pydash_app/dashboard/endpoint.py
@@ -1,6 +1,7 @@
-
 import uuid
 import persistent
+
+from .aggregator import Aggregator
 
 
 class Endpoint(persistent.Persistent):
@@ -20,8 +21,10 @@ class Endpoint(persistent.Persistent):
 
         self.id = uuid.uuid4()
         self.name = name
-        self.calls = list()
         self.is_monitored = is_monitored
+
+        self._calls = []
+        self._aggregator = Aggregator(self._calls)
 
     def __repr__(self):
         return f'{self.__class__.__name__} id={self.id} name={self.name}'
@@ -34,7 +37,8 @@ class Endpoint(persistent.Persistent):
         Adds a call to its internal collection of endpoint calls.
         :param call: The endpoint call to add.
         """
-        self.calls.append(call)
+        self._calls.append(call)
+        self._aggregator.add_endpoint_call(call)
 
     def remove_call(self, call):
         """
@@ -43,7 +47,7 @@ class Endpoint(persistent.Persistent):
         :param call: The endpoint call to remove.
         """
         try:
-            self.calls.remove(call)
+            self._calls.remove(call)
         except ValueError:
             raise
 

--- a/pydash/pydash_app/dashboard/endpoint.py
+++ b/pydash/pydash_app/dashboard/endpoint.py
@@ -53,3 +53,10 @@ class Endpoint(persistent.Persistent):
 
     def set_monitored(self, is_monitored):
         self.is_monitored = is_monitored
+
+    def get_aggregated_data(self):
+        """
+        Get aggregated data on this endpoint.
+        :return: A dict containing aggregated data points.
+        """
+        return self._aggregator.as_dict()

--- a/pydash/pydash_app/dashboard/endpoint_call.py
+++ b/pydash/pydash_app/dashboard/endpoint_call.py
@@ -1,4 +1,3 @@
-
 import persistent
 from datetime import datetime
 
@@ -47,7 +46,7 @@ class EndpointCall(persistent.Persistent):
             raise TypeError('EndpointCall expects ip to be a string.')
 
     # Note: this function only exists to provide an interface and abstract away from internal representation.
-    def get_data(self):
+    def as_dict(self):
         """returns a dict containing the data of the EndpointCall"""
         return {"endpoint": self.endpoint,
                 "execution_time": self.execution_time,
@@ -55,4 +54,4 @@ class EndpointCall(persistent.Persistent):
                 "version": self.version,
                 "group_by": self.group_by,
                 "ip": self.ip
-                }
+        }


### PR DESCRIPTION
Adds the `Aggregator` class, which contains functionality to maintain aggregate data for either a dashboard or a single endpoint, and update this data every time an endpoint call is added.

Currently supported metrics are:
- total visits
- total execution time
- average execution time
- visits per day
- visits per IP

This can easily be extended as well.

Fixes #95 