### PR TITLE
Split pydash_web into "api" and "static" blueprints, and correctly serve static files

### DIFF
--- a/pydash/pydash_web/__init__.py
+++ b/pydash/pydash_web/__init__.py
@@ -18,7 +18,7 @@ import pydash_app.user
 import pydash_app.dashboard
 
 
-flask_webapp = Flask(__name__, static_folder="../../pydash-front/build", static_url_path="")
+flask_webapp = Flask(__name__)
 flask_webapp.config.from_object(Config)
 
 flask_webapp.config['CORS_HEADERS'] = 'Content-Type'

--- a/pydash/pydash_web/__init__.py
+++ b/pydash/pydash_web/__init__.py
@@ -7,7 +7,9 @@ Initializes a Flask web application, and loads the relevant configuration settin
 from flask import Flask
 from flask_login import LoginManager
 from flask_cors import CORS
-from pydash_web.blueprint import bp as pydash_web_bp
+
+from pydash_web.api import api as api_blueprint
+
 
 from config import Config
 
@@ -18,10 +20,13 @@ import pydash_app.dashboard
 
 flask_webapp = Flask(__name__, static_folder="../../pydash-front/build", static_url_path="")
 flask_webapp.config.from_object(Config)
-login_manager = LoginManager(flask_webapp)
-flask_webapp.register_blueprint(pydash_web_bp)
+
 flask_webapp.config['CORS_HEADERS'] = 'Content-Type'
 cors = CORS(flask_webapp, resources={r"/api/*": {"origins": "*"}}, allow_headers=['Content-Type'], supports_credentials=True) # Only keep this during development!
+
+flask_webapp.register_blueprint(api_blueprint)
+
+login_manager = LoginManager(flask_webapp)
 
 
 @login_manager.user_loader

--- a/pydash/pydash_web/__init__.py
+++ b/pydash/pydash_web/__init__.py
@@ -9,7 +9,7 @@ from flask_login import LoginManager
 from flask_cors import CORS
 
 from pydash_web.api import api as api_blueprint
-
+from pydash_web.static import static as static_blueprint
 
 from config import Config
 
@@ -25,6 +25,7 @@ flask_webapp.config['CORS_HEADERS'] = 'Content-Type'
 cors = CORS(flask_webapp, resources={r"/api/*": {"origins": "*"}}, allow_headers=['Content-Type'], supports_credentials=True) # Only keep this during development!
 
 flask_webapp.register_blueprint(api_blueprint)
+flask_webapp.register_blueprint(static_blueprint)
 
 login_manager = LoginManager(flask_webapp)
 

--- a/pydash/pydash_web/api.py
+++ b/pydash/pydash_web/api.py
@@ -7,6 +7,6 @@ route decorators in this package should also use this blueprint object instead o
 
 from flask import Blueprint
 
-bp = Blueprint('pydash_web', __name__, static_folder="../../pydash-front/build", static_url_path="")
+api = Blueprint('pydash_web.api', __name__, static_folder="../../pydash-front/build", static_url_path="")
 
-from pydash_web import routes  #link routes to blueprint
+import pydash_web.api_routes

--- a/pydash/pydash_web/api.py
+++ b/pydash/pydash_web/api.py
@@ -7,6 +7,6 @@ route decorators in this package should also use this blueprint object instead o
 
 from flask import Blueprint
 
-api = Blueprint('pydash_web.api', __name__, static_folder="../../pydash-front/build", static_url_path="")
+api = Blueprint('pydash_web.api', __name__)
 
 import pydash_web.api_routes

--- a/pydash/pydash_web/api_routes.py
+++ b/pydash/pydash_web/api_routes.py
@@ -5,35 +5,34 @@ The actual implementation of each of the routes' dispatching logic is handled by
 """
 
 from flask_login import login_required
-from flask_cors import cross_origin
 
-from pydash_web.blueprint import bp
+from pydash_web.api import api
 import pydash_web.controller as controller
 
 
-@bp.route("/api/login", methods=["POST"])
+@api.route("/api/login", methods=["POST"])
 def login():
     return controller.login()
 
 
-@bp.route("/api/logout", methods=["POST"])
+@api.route("/api/logout", methods=["POST"])
 def logout():
     return controller.logout()
 
 
-@bp.route("/api/dashboards", methods=["GET"])
+@api.route("/api/dashboards", methods=["GET"])
 @login_required
 def get_dashboards():
     return controller.dashboards()
 
 
-@bp.route("/api/dashboards/<dashboard_id>", methods=["GET"])
+@api.route("/api/dashboards/<dashboard_id>", methods=["GET"])
 @login_required
 def get_dashboard(dashboard_id):
     return controller.dashboard(dashboard_id)
 
 
-@bp.route("/", defaults={'path': ''})
-@bp.route("/<path:path>")
+@api.route("/", defaults={'path': ''})
+@api.route("/<path:path>")
 def serve_react(path):
-    return bp.send_static_file("index.html")
+    return api.send_static_file("index.html")

--- a/pydash/pydash_web/api_routes.py
+++ b/pydash/pydash_web/api_routes.py
@@ -30,9 +30,3 @@ def get_dashboards():
 @login_required
 def get_dashboard(dashboard_id):
     return controller.dashboard(dashboard_id)
-
-
-@api.route("/", defaults={'path': ''})
-@api.route("/<path:path>")
-def serve_react(path):
-    return api.send_static_file("index.html")

--- a/pydash/pydash_web/static.py
+++ b/pydash/pydash_web/static.py
@@ -1,0 +1,7 @@
+from flask import Blueprint
+
+static = Blueprint('pydash_web.static', __name__,
+                   static_folder='../../pydash-front/build/static',
+                   static_url_path='/static')
+
+import pydash_web.static_routes

--- a/pydash/pydash_web/static_routes.py
+++ b/pydash/pydash_web/static_routes.py
@@ -1,0 +1,14 @@
+from flask import send_from_directory
+
+from pydash_web.static import static
+
+
+@static.route('/service-worker.js')
+def serve_worker():
+    return send_from_directory('../../pydash-front/build', 'service-worker.js')
+
+
+@static.route('/', defaults={'path': ''})
+@static.route('/<path:path>')
+def serve_react(path):
+    return send_from_directory('../../pydash-front/build', 'index.html')


### PR DESCRIPTION
This PR will split up the `pydash_web` package into two blueprints: `api` and `static`.
When deploying, we will likely want to serve static files directly using for example nginx. Therefore this change will make it easier to disable the serving of static files/the React app.