### PR TITLE
Add dashboards for all users when seeding, instead of only for W-M and Koen

### DIFF
--- a/pydash/pydash_app/dashboard/dashboard_repository.py
+++ b/pydash/pydash_app/dashboard/dashboard_repository.py
@@ -99,8 +99,7 @@ def seed_dashboards():
 
     # TEST
     from pydash_app.fetching.dashboard_fetch import initialize_endpoints, initialize_endpoint_calls
-    #for user in user_repository.all():
-    for user in [user_repository.find_by_name('W-M'), user_repository.find_by_name('Koen')]:
+    for user in user_repository.all():
         dashboard = Dashboard("http://136.243.248.188:9001/dashboard",
                               "cc83733cb0af8b884ff6577086b87909",
                               user.get_id())


### PR DESCRIPTION
This accidentally ended up in development and needs to be rolled back.