### PR TITLE
Improve error handling when fetching

### DIFF
--- a/pydash/flask_monitoring_dashboard_client/__init__.py
+++ b/pydash/flask_monitoring_dashboard_client/__init__.py
@@ -78,7 +78,7 @@ def get_data(dashboard_url, dashboard_token, time_from=None, time_to=None):
 
     if time_from is None and time_to is not None:
         logger.error('Invalid input parameter combination: when time_from is None, time_to may not be specified.')
-        return None
+        raise ValueError('when time_from is None, time_to may not be specified')
 
     if time_from is not None:
         time_from = int(time_from.timestamp())

--- a/pydash/flask_monitoring_dashboard_client/__init__.py
+++ b/pydash/flask_monitoring_dashboard_client/__init__.py
@@ -12,11 +12,12 @@ import json
 
 import pydash_logger
 
-DETAILS_ENDPOINT = 0
-RULES_ENDPOINT = 1
-DATA_ENDPOINT = 2
+_DETAILS_ENDPOINT = 0
+_RULES_ENDPOINT = 1
+_DATA_ENDPOINT = 2
 
 logger = pydash_logger.Logger(__name__)
+
 
 def get_details(dashboard_url):
     """
@@ -24,7 +25,7 @@ def get_details(dashboard_url):
     :param dashboard_url: The base URL for the deployed dashboard, without trailing slash
     :return: A dict containing details from the dashboard, or None if the request was unsuccessful
     """
-    endpoint = _endpoint_name(DETAILS_ENDPOINT)
+    endpoint = _endpoint_name(_DETAILS_ENDPOINT)
 
     response = requests.get(f'{dashboard_url}/{endpoint}')
 
@@ -41,7 +42,7 @@ def get_monitor_rules(dashboard_url, dashboard_token):
     :param dashboard_token: The secret token for the dashboard, used to decode the Json Web Token response
     :return: A dict containing monitor rules of the dashboard, or None if the request was unsuccessful
     """
-    endpoint = _endpoint_name(RULES_ENDPOINT)
+    endpoint = _endpoint_name(_RULES_ENDPOINT)
 
     response = requests.get(f'{dashboard_url}/{endpoint}')
 
@@ -57,15 +58,16 @@ def get_data(dashboard_url, dashboard_token, time_from=None, time_to=None):
     :param dashboard_url: The base URL for the deployed dashboard, without trailing slash
     :param dashboard_token: The secret token for the dashboard, used to decode the Json Web Token response
     :param time_from: An optional datetime indicating only data since that moment should be included
-    :param time_to: An optional datetime indicating only data up to that point should be included
-    :return: A dict containing all monitoring data or data since a given timestamp
+    :param time_to: An optional datetime indicating only data up to that point should be included;
+    only valid if time_from is also specified
+    :return: A dict containing all monitoring data, possibly limited to the given time range
     """
-    endpoint = _endpoint_name(DATA_ENDPOINT)
+    endpoint = _endpoint_name(_DATA_ENDPOINT)
 
     url = f'{dashboard_url}/{endpoint}'
 
     if time_from is None and time_to is not None:
-        logger.error('Invalid input paramater combination: when time_from is None, time_to may not be specified.')
+        logger.error('Invalid input parameter combination: when time_from is None, time_to may not be specified.')
         return None
 
     if time_from is not None:

--- a/pydash/flask_monitoring_dashboard_client/__init__.py
+++ b/pydash/flask_monitoring_dashboard_client/__init__.py
@@ -6,7 +6,7 @@ The method names in this module 1:1 reflect the names of the flask-monitoring-da
 is one of the thing this module handles for you.)
 """
 
-import requests
+import requests, requests.exceptions
 import jwt
 import json
 
@@ -27,7 +27,11 @@ def get_details(dashboard_url):
     """
     endpoint = _endpoint_name(_DETAILS_ENDPOINT)
 
-    response = requests.get(f'{dashboard_url}/{endpoint}')
+    try:
+        response = requests.get(f'{dashboard_url}/{endpoint}')
+    except requests.exceptions.ConnectionError as e:
+        logger.error(f'Connection error in get_details: {e}')
+        raise
 
     if response.status_code != 200:
         logger.error(f'Bad response status code in get_details: {response.status_code}')
@@ -45,7 +49,11 @@ def get_monitor_rules(dashboard_url, dashboard_token):
     """
     endpoint = _endpoint_name(_RULES_ENDPOINT)
 
-    response = requests.get(f'{dashboard_url}/{endpoint}')
+    try:
+        response = requests.get(f'{dashboard_url}/{endpoint}')
+    except requests.exceptions.ConnectionError as e:
+        logger.error(f'Connection error in get_monitor_rules: {e}')
+        raise
 
     if response.status_code != 200:
         logger.error(f'Bad response status code in get_monitor_rules: {response.status_code}')
@@ -79,7 +87,11 @@ def get_data(dashboard_url, dashboard_token, time_from=None, time_to=None):
         time_to = int(time_to.timestamp())
         url = f'{url}/{time_to}'
 
-    response = requests.get(url)
+    try:
+        response = requests.get(url)
+    except requests.exceptions.ConnectionError:
+        logger.error(f'Connection error in get_data: {e}')
+        raise
 
     if response.status_code != 200:
         logger.error(f'Bad response status code in get_data: {response.status_code}')

--- a/pydash/flask_monitoring_dashboard_client/__init__.py
+++ b/pydash/flask_monitoring_dashboard_client/__init__.py
@@ -35,7 +35,7 @@ def get_details(dashboard_url):
 
     if response.status_code != 200:
         logger.error(f'Bad response status code in get_details: {response.status_code}')
-        return None
+        response.raise_for_status()
 
     return json.loads(response.text)
 
@@ -57,7 +57,7 @@ def get_monitor_rules(dashboard_url, dashboard_token):
 
     if response.status_code != 200:
         logger.error(f'Bad response status code in get_monitor_rules: {response.status_code}')
-        return None
+        response.raise_for_status()
 
     return _decode_jwt(response.text, dashboard_token)
 
@@ -95,7 +95,7 @@ def get_data(dashboard_url, dashboard_token, time_from=None, time_to=None):
 
     if response.status_code != 200:
         logger.error(f'Bad response status code in get_data: {response.status_code}')
-        return None
+        response.raise_for_status()
 
     return _decode_jwt(response.text, dashboard_token)
 

--- a/pydash/flask_monitoring_dashboard_client/__init__.py
+++ b/pydash/flask_monitoring_dashboard_client/__init__.py
@@ -37,7 +37,11 @@ def get_details(dashboard_url):
         logger.error(f'Bad response status code in get_details: {response.status_code}')
         response.raise_for_status()
 
-    return json.loads(response.text)
+    try:
+        return json.loads(response.text)
+    except json.JSONDecodeError:
+        logger.error('Response to get_json_details contains malformed JSON')
+        raise
 
 
 def get_monitor_rules(dashboard_url, dashboard_token):

--- a/pydash/pydash_app/dashboard/dashboard.py
+++ b/pydash/pydash_app/dashboard/dashboard.py
@@ -37,8 +37,7 @@ import uuid
 import persistent
 
 from pydash_app.dashboard.endpoint import Endpoint
-from .aggregator import Aggregator
-
+from pydash_app.dashboard.aggregator import Aggregator
 
 
 class Dashboard(persistent.Persistent):

--- a/pydash/pydash_app/dashboard/dashboard.py
+++ b/pydash/pydash_app/dashboard/dashboard.py
@@ -44,6 +44,15 @@ from pydash_app.dashboard.aggregator import Aggregator
 class DashboardStatus(Enum):
     not_initialized = 0
 
+    initialized_endpoints = 10
+    initialize_endpoints_failure = 11
+
+    initialized_endpoint_calls = 20
+    initialize_endpoint_calls_failure = 21
+
+    fetched_endpoint_calls = 30
+    fetch_endpoint_calls_failure = 31
+
 
 class Dashboard(persistent.Persistent):
     """
@@ -66,7 +75,7 @@ class Dashboard(persistent.Persistent):
         self.token = token
 
         self.last_fetch_time = None
-        self.last_fetch_status = DashboardStatus.not_initialized
+        self.status = DashboardStatus.not_initialized
 
         self._endpoint_calls = []  # list of unfiltered endpoint calls, for use with an aggregator.
         self._aggregator = Aggregator(self._endpoint_calls)

--- a/pydash/pydash_app/dashboard/dashboard.py
+++ b/pydash/pydash_app/dashboard/dashboard.py
@@ -35,9 +35,14 @@ Involved usage example:
 
 import uuid
 import persistent
+from enum import Enum
 
 from pydash_app.dashboard.endpoint import Endpoint
 from pydash_app.dashboard.aggregator import Aggregator
+
+
+class DashboardStatus(Enum):
+    not_initialized = 0
 
 
 class Dashboard(persistent.Persistent):
@@ -58,8 +63,10 @@ class Dashboard(persistent.Persistent):
         self.url = url
         self.user_id = uuid.UUID(user_id)
         self.endpoints = dict()  # name -> Endpoint
-        self.last_fetch_time = None
         self.token = token
+
+        self.last_fetch_time = None
+        self.last_fetch_status = DashboardStatus.not_initialized
 
         self._endpoint_calls = []  # list of unfiltered endpoint calls, for use with an aggregator.
         self._aggregator = Aggregator(self._endpoint_calls)

--- a/pydash/pydash_app/dashboard/dashboard.py
+++ b/pydash/pydash_app/dashboard/dashboard.py
@@ -42,6 +42,26 @@ from pydash_app.dashboard.aggregator import Aggregator
 
 
 class DashboardState(Enum):
+    """
+    The DashboardState enum indicates the state in which a Dashboard can remain, regarding remote fetching:
+
+    - not_initialized indicates the dashboard is newly created and not initialized with Endpoints and
+      historic EndpointCalls;
+
+    - initialized_endpoints indicates the dashboard has successfully initialized Endpoints,
+      but not yet historical EndpointCalls;
+    - initialize_endpoints_failure indicates something went wrong while initializing Endpoints, which means
+      initialization of Endpoints needs to be retried;
+
+    - initialized_endpoint_calls indicates the dashboard has successfully initialized historical EndpointCalls,
+      and can start fetching new EndpointCalls in a periodic task;
+    - initialize_endpoint_calls_failure indicates something went wrong while initializing historical EndpointCalls,
+      which means this needs to be retried;
+
+    - fetched_endpoint_calls indicates last time new EndpointCalls were fetched, it was done successfully;
+    - fetch_endpoint_calls_failure indicates something went wrong while fetching new EndpointCalls,
+      which means this needs to be retried.
+    """
     not_initialized = 0
 
     initialized_endpoints = 10

--- a/pydash/pydash_app/dashboard/dashboard.py
+++ b/pydash/pydash_app/dashboard/dashboard.py
@@ -76,6 +76,7 @@ class Dashboard(persistent.Persistent):
 
         self.last_fetch_time = None
         self.status = DashboardStatus.not_initialized
+        self.error = None
 
         self._endpoint_calls = []  # list of unfiltered endpoint calls, for use with an aggregator.
         self._aggregator = Aggregator(self._endpoint_calls)

--- a/pydash/pydash_app/dashboard/dashboard.py
+++ b/pydash/pydash_app/dashboard/dashboard.py
@@ -41,7 +41,7 @@ from pydash_app.dashboard.endpoint import Endpoint
 from pydash_app.dashboard.aggregator import Aggregator
 
 
-class DashboardStatus(Enum):
+class DashboardState(Enum):
     not_initialized = 0
 
     initialized_endpoints = 10
@@ -75,7 +75,7 @@ class Dashboard(persistent.Persistent):
         self.token = token
 
         self.last_fetch_time = None
-        self.status = DashboardStatus.not_initialized
+        self.state = DashboardState.not_initialized
         self.error = None
 
         self._endpoint_calls = []  # list of unfiltered endpoint calls, for use with an aggregator.

--- a/pydash/pydash_app/dashboard/services/fetching.py
+++ b/pydash/pydash_app/dashboard/services/fetching.py
@@ -233,17 +233,18 @@ def fetch_and_add_endpoint_calls(dashboard):
     new_calls = _fetch_endpoint_calls(
         dashboard, time_from=dashboard.last_fetch_time)
 
-    logger.info(f"New endpoint calls: {new_calls}")
+    if not new_calls:
+        logger.info(f'No new calls for dashboard: {dashboard}')
+        return
 
-    if new_calls is []:
-        return []
+    logger.info(f'New endpoint calls: {new_calls}')
 
     for call in new_calls:
         dashboard.add_endpoint_call(call)
 
     dashboard.last_fetch_time = new_calls[-1].time
 
-    logger.info(f"Saved to database: dashboard {dashboard}")
+    logger.info(f'Saved to database: dashboard {dashboard}')
 
 
 def _fetch_endpoint_calls(dashboard, time_from=None, time_to=None):

--- a/pydash/pydash_app/dashboard/services/fetching.py
+++ b/pydash/pydash_app/dashboard/services/fetching.py
@@ -291,6 +291,8 @@ def fetch_and_add_endpoint_calls(dashboard):
         dashboard.add_endpoint_call(call)
 
     dashboard.last_fetch_time = new_calls[-1].time
+    dashboard.state = DashboardState.fetched_endpoint_calls
+    dashboard.error = None
 
     logger.info(f'Saved to database: dashboard {dashboard}')
 

--- a/pydash/pydash_app/dashboard/services/fetching.py
+++ b/pydash/pydash_app/dashboard/services/fetching.py
@@ -126,6 +126,8 @@ def fetch_and_add_endpoints(dashboard):
     for endpoint in endpoints:
         dashboard.add_endpoint(endpoint)
 
+    dashboard.state = DashboardState.initialized_endpoints
+
 
 def _fetch_endpoints(dashboard):
     """

--- a/pydash/pydash_app/dashboard/services/fetching.py
+++ b/pydash/pydash_app/dashboard/services/fetching.py
@@ -77,7 +77,7 @@ def fetch_and_update_new_dashboard_info(dashboard_id):
     """
     dashboard = dashboard_repository.find(dashboard_id)
 
-    logger.info("INSIDE FETCH FUNCTION")
+    logger.info(f'INSIDE FETCH FUNCTION: {dashboard_id}')
 
     fetch_and_add_endpoint_calls(dashboard)
 
@@ -86,10 +86,7 @@ def fetch_and_update_new_dashboard_info(dashboard_id):
 
     dashboard_repository.update(dashboard)
 
-    logger.info(f'{len(dashboard.endpoints)} endpoints found')
-    logger.info(f'{len(dashboard._endpoint_calls)} endpoint calls')
-
-    logger.info(f"Dashboard {dashboard_id} updated.")
+    logger.info(f"Dashboard {dashboard_id} updated")
 
 
 def fetch_and_update_historic_dashboard_info(dashboard_id):
@@ -98,7 +95,7 @@ def fetch_and_update_historic_dashboard_info(dashboard_id):
     """
     dashboard = dashboard_repository.find(dashboard_id)
 
-    logger.info("INSIDE INITIAL DASHBOARD FETCHING FUNCTION")
+    logger.info(f'INSIDE INITIAL FETCHING FUNCTION: {dashboard_id}')
 
     fetch_and_add_endpoints(dashboard)
     fetch_and_add_historic_endpoint_calls(dashboard)
@@ -108,8 +105,8 @@ def fetch_and_update_historic_dashboard_info(dashboard_id):
 
     dashboard_repository.update(dashboard)
 
-    logger.info(f'{len(dashboard.endpoints)} endpoints found')
-    logger.info(f'{len(dashboard._endpoint_calls)} historical endpoint calls')
+
+# Endpoints
 
 
 def fetch_and_add_endpoints(dashboard):
@@ -207,6 +204,9 @@ def fetch_and_add_historic_endpoint_calls(dashboard):
             dashboard.last_fetch_time = call.time
 
         start_time = end_time
+
+
+# EndpointCalls
 
 
 def fetch_and_add_endpoint_calls(dashboard):

--- a/pydash/pydash_app/dashboard/services/fetching.py
+++ b/pydash/pydash_app/dashboard/services/fetching.py
@@ -106,7 +106,7 @@ def fetch_and_update_historic_dashboard_info(dashboard_id):
     dashboard_repository.update(dashboard)
 
 
-# Initializing Endpoints
+# Endpoints
 
 
 def fetch_and_add_endpoints(dashboard):
@@ -145,7 +145,7 @@ def _fetch_endpoints(dashboard):
     ]
 
 
-# Initializing EndpointCalls
+# EndpointCalls
 
 
 def fetch_and_add_historic_endpoint_calls(dashboard):

--- a/pydash/pydash_app/dashboard/services/fetching.py
+++ b/pydash/pydash_app/dashboard/services/fetching.py
@@ -118,7 +118,7 @@ def fetch_and_add_endpoints(dashboard):
 
     # Only run this function if no endpoints have been added yet
     if dashboard.state != DashboardState.not_initialized:
-        logger.warning(f'Tried to add endpoints from a wrong state: {dashboard.state}')
+        logger.warning(f'Tried to add endpoints from a wrong state: {dashboard.state} for dashboard: {dashboard}')
         return
 
     endpoints = _fetch_endpoints(dashboard)
@@ -156,7 +156,8 @@ def fetch_and_add_historic_endpoint_calls(dashboard):
 
     # Only run this function if no periodic fetching of latest information has happened yet:
     if dashboard.state != DashboardState.initialized_endpoints:
-        logger.warning(f'Tried to add historic endpoint calls from a wrong state: {dashboard.state}')
+        logger.warning(
+            f'Tried to add historic endpoint calls from a wrong state: {dashboard.state} for dashboard: {dashboard}')
         return
 
     try:
@@ -232,7 +233,8 @@ def fetch_and_add_endpoint_calls(dashboard):
         DashboardState.fetch_endpoint_calls_failure
     )
     if dashboard.state not in allowed_states:
-        logger.warning(f'Tried to add new endpoint calls from a wrong state: {dashboard.state}')
+        logger.warning(
+            f'Tried to add new endpoint calls from a wrong state: {dashboard.state} for dashboard: {dashboard}')
         return
 
     new_calls = _fetch_endpoint_calls(

--- a/pydash/pydash_app/dashboard/services/fetching.py
+++ b/pydash/pydash_app/dashboard/services/fetching.py
@@ -1,7 +1,6 @@
 from functools import partial
 from datetime import datetime, timedelta, timezone
 
-import pydash_database
 import flask_monitoring_dashboard_client
 from pydash_app.dashboard.endpoint import Endpoint
 from pydash_app.dashboard.endpoint_call import EndpointCall

--- a/pydash/pydash_app/dashboard/services/fetching.py
+++ b/pydash/pydash_app/dashboard/services/fetching.py
@@ -5,7 +5,10 @@ import flask_monitoring_dashboard_client
 from pydash_app.dashboard.endpoint import Endpoint
 from pydash_app.dashboard.endpoint_call import EndpointCall
 import pydash_app.dashboard.repository as dashboard_repository
+import pydash_logger
 import periodic_tasks
+
+logger = pydash_logger.Logger(__name__)
 
 
 def schedule_all_periodic_dashboards_tasks(
@@ -32,7 +35,8 @@ def schedule_periodic_dashboard_fetching(
     """
     Schedules the periodic EndpointCall fetching task for this dashboard.
     """
-    print(f'Creating periodic fetching task for {dashboard}')
+    logger.info(f'Creating periodic fetching task for {dashboard}')
+
     periodic_tasks.add_periodic_task(
         name=("dashboard", dashboard.id, "fetching"),
         task=partial(fetch_and_update_new_dashboard_info, dashboard.id),
@@ -62,18 +66,20 @@ def fetch_and_update_new_dashboard_info(dashboard_id):
     Updates the dashboard with the new EndpointCall information that is fetched from the Dashboard's remote location.
     """
     dashboard = dashboard_repository.find(dashboard_id)
-    print("INSIDE FETCH FUNCTION")
+
+    logger.info("INSIDE FETCH FUNCTION")
+
     fetch_and_add_endpoint_calls(dashboard)
 
-    print(f'- {len(dashboard.endpoints)} endpoints found')
-    print(f'- {len(dashboard._endpoint_calls)} endpoint calls')
+    logger.info(f'{len(dashboard.endpoints)} endpoints found')
+    logger.info(f'{len(dashboard._endpoint_calls)} endpoint calls')
 
     dashboard_repository.update(dashboard)
 
-    print(f'- {len(dashboard.endpoints)} endpoints found')
-    print(f'- {len(dashboard._endpoint_calls)} endpoint calls')
+    logger.info(f'{len(dashboard.endpoints)} endpoints found')
+    logger.info(f'{len(dashboard._endpoint_calls)} endpoint calls')
 
-    print(f"Dashboard {dashboard_id} updated.")
+    logger.info(f"Dashboard {dashboard_id} updated.")
 
 
 def fetch_and_update_historic_dashboard_info(dashboard_id):
@@ -81,17 +87,19 @@ def fetch_and_update_historic_dashboard_info(dashboard_id):
     Updates the dashboard with the historic EndpointCall information that is fetched from the Dashboard's remote location.
     """
     dashboard = dashboard_repository.find(dashboard_id)
-    print("INSIDE INITIAL DASHBOARD FETCHING FUNCTION")
+
+    logger.info("INSIDE INITIAL DASHBOARD FETCHING FUNCTION")
+
     fetch_and_add_endpoints(dashboard)
     fetch_and_add_historic_endpoint_calls(dashboard)
 
-    print(f'- {len(dashboard.endpoints)} endpoints found')
-    print(f'- {len(dashboard._endpoint_calls)} historical endpoint calls')
+    logger.info(f'{len(dashboard.endpoints)} endpoints found')
+    logger.info(f'{len(dashboard._endpoint_calls)} historical endpoint calls')
 
     dashboard_repository.update(dashboard)
 
-    print(f'- {len(dashboard.endpoints)} endpoints found')
-    print(f'- {len(dashboard._endpoint_calls)} historical endpoint calls')
+    logger.info(f'{len(dashboard.endpoints)} endpoints found')
+    logger.info(f'{len(dashboard._endpoint_calls)} historical endpoint calls')
 
 
 def fetch_and_add_endpoints(dashboard):
@@ -165,7 +173,8 @@ def fetch_and_add_endpoint_calls(dashboard):
     Retrieve the latest endpoint calls of the given dashboard and add them to it.
     :param dashboard: The dashboard for which to update endpoint calls.
     """
-    print(f"Updating endpoint calls for dashboard: {dashboard}")
+
+    logger.info(f"Updating endpoint calls for dashboard: {dashboard}")
 
     # Only run this function if historic fetching has happened.
     if dashboard.last_fetch_time is None:
@@ -173,7 +182,8 @@ def fetch_and_add_endpoint_calls(dashboard):
 
     new_calls = _fetch_endpoint_calls(
         dashboard, time_from=dashboard.last_fetch_time)
-    print(f"New endpoint calls: {new_calls}")
+
+    logger.info(f"New endpoint calls: {new_calls}")
 
     if new_calls is []:
         return []
@@ -182,7 +192,8 @@ def fetch_and_add_endpoint_calls(dashboard):
         dashboard.add_endpoint_call(call)
 
     dashboard.last_fetch_time = new_calls[-1].time
-    print(f"Saved to database: dashboard {dashboard}")
+
+    logger.info(f"Saved to database: dashboard {dashboard}")
 
 
 def _fetch_endpoint_calls(dashboard, time_from=None, time_to=None):

--- a/pydash/pydash_app/dashboard/services/fetching.py
+++ b/pydash/pydash_app/dashboard/services/fetching.py
@@ -22,14 +22,14 @@ def schedule_all_periodic_dashboards_tasks(
     Sets up all tasks that should be run periodically for each of the dashboards.
     (For now, that is only the EndpointCall fetching task.)
     """
+    initialization_states = (
+        DashboardState.not_initialized,
+        DashboardState.initialized_endpoints,
+        DashboardState.initialize_endpoints_failure,
+        DashboardState.initialized_endpoint_calls,
+        DashboardState.initialize_endpoint_calls_failure
+    )
     for dashboard in dashboard_repository.all():
-        initialization_states = (
-            DashboardState.not_initialized,
-            DashboardState.initialized_endpoints,
-            DashboardState.initialize_endpoints_failure,
-            DashboardState.initialized_endpoint_calls,
-            DashboardState.initialize_endpoint_calls_failure
-        )
         if dashboard.state in initialization_states:
             schedule_historic_dashboard_fetching(
                 dashboard, scheduler=scheduler)
@@ -106,7 +106,7 @@ def fetch_and_update_historic_dashboard_info(dashboard_id):
     dashboard_repository.update(dashboard)
 
 
-# Endpoints
+# Initializing Endpoints
 
 
 def fetch_and_add_endpoints(dashboard):
@@ -138,6 +138,9 @@ def _fetch_endpoints(dashboard):
     return [
         Endpoint(rule['endpoint'], rule['monitor']) for rule in monitor_rules
     ]
+
+
+# Initializing EndpointCalls
 
 
 def fetch_and_add_historic_endpoint_calls(dashboard):
@@ -204,9 +207,6 @@ def fetch_and_add_historic_endpoint_calls(dashboard):
             dashboard.last_fetch_time = call.time
 
         start_time = end_time
-
-
-# EndpointCalls
 
 
 def fetch_and_add_endpoint_calls(dashboard):

--- a/pydash/pydash_app/dashboard/services/fetching.py
+++ b/pydash/pydash_app/dashboard/services/fetching.py
@@ -116,6 +116,11 @@ def fetch_and_add_endpoints(dashboard):
     :param dashboard: The dashboard to initialize with endpoints.
     """
 
+    # Only run this function if no endpoints have been added yet
+    if dashboard.state != DashboardState.not_initialized:
+        logger.warning(f'Tried to add endpoints from a wrong state: {dashboard.state}')
+        return
+
     endpoints = _fetch_endpoints(dashboard)
 
     for endpoint in endpoints:

--- a/pydash/pydash_app/dashboard/services/fetching.py
+++ b/pydash/pydash_app/dashboard/services/fetching.py
@@ -163,17 +163,20 @@ def fetch_and_add_historic_endpoint_calls(dashboard):
     try:
         details = flask_monitoring_dashboard_client.get_details(dashboard.url)
     except requests.exceptions.ConnectionError as e:
-        logger.error(f'Connection error happened while initializing EndpointCalls: {e}')
+        logger.error(f'Connection error happened while initializing EndpointCalls: {e}\n'
+                     f'for dashboard: {dashboard}')
         dashboard.state = DashboardState.initialize_endpoint_calls_failure
         dashboard.error = str(e)
         return
     except requests.exceptions.HTTPError as e:
-        logger.error(f'HTTP error happened while initializing EndpointCalls: {e}')
+        logger.error(f'HTTP error happened while initializing EndpointCalls: {e}\n'
+                     f'for dashboard: {dashboard}')
         dashboard.state = DashboardState.initialize_endpoint_calls_failure
         dashboard.error = str(e)
         return
     except json.JSONDecodeError as e:
-        logger.error(f'JSON decode error happened while initializing EndpointCalls: {e}')
+        logger.error(f'JSON decode error happened while initializing EndpointCalls: {e}\n'
+                     f'for dashboard: {dashboard}')
         dashboard.state = DashboardState.initialize_endpoint_calls_failure
         dashboard.error = str(e)
         return

--- a/pydash/pydash_app/dashboard/services/fetching.py
+++ b/pydash/pydash_app/dashboard/services/fetching.py
@@ -137,11 +137,12 @@ def _fetch_endpoints(dashboard):
     :return: A list of `Endpoint`s for the dashboard.
     """
 
+    # Note: exceptions raised by flask_monitoring_dashboard_client.get_monitor_rules
+    # are simply propagated upwards, since this is not the best place
+    # to handle them; this function is meant to be more or less "pure"
+
     monitor_rules = flask_monitoring_dashboard_client.get_monitor_rules(
         dashboard.url, dashboard.token)
-
-    if monitor_rules is None:
-        return []
 
     return [
         Endpoint(rule['endpoint'], rule['monitor']) for rule in monitor_rules

--- a/pydash/pydash_web/__init__.py
+++ b/pydash/pydash_web/__init__.py
@@ -29,7 +29,7 @@ cors = CORS(flask_webapp, resources={r"/api/*": {"origins": "*"}}, allow_headers
 flask_webapp.register_blueprint(api_blueprint)
 flask_webapp.register_blueprint(react_server_blueprint)
 
-pydash_app.schedule_periodic_tasks()
+#pydash_app.schedule_periodic_tasks()
 
 
 # Don't autostart scheduler in the testing environment.


### PR DESCRIPTION
This is a rather big PR that refactors most of the fetching core logic.

It adds proper exceptions to most functionality in `flask_monitoring_dashboard_client` and `pydash_app.dashboard.services.fetching`, as well as logging.

It also turns the `Dashboard` entity into a state machine with regards to fetching. These states are described in the `pydash_app.dashboard.dashboard.DashboardState` enum. Moreover, it adds an `error` property to `Dashboard` which could be returned from the backend API.

I've described most changes in #135.

As I mention there:
>What remains is to test the error handling under several conditions:

I have tested running `flask seed` under normal conditions -- I needed to temporarily turn off periodic tasks, because these tasks tried to refer to the `state` field before it existed in dashboards in the database: we might need to fix this so that everyone can test. It shouldn't matter for production though. This worked perfectly and the dashboards were initialized properly.

I have yet to test periodic fetching.

I also have not yet tested either seeding or periodic fetching under erroneous conditions (for a list of cases that are handled and need to be tested, see #135). I will do this, but I would also like to ask the other backenders @TWEApol @TheVeggydude (@Qqwy ?) to test some of these conditions.