### PR TITLE
Fixes front-end on different port; useful error handling while logging in

### DIFF
--- a/pydash-front/src/app/boards/GraphGrid.js
+++ b/pydash-front/src/app/boards/GraphGrid.js
@@ -40,7 +40,7 @@ class GraphGrid extends Component {
     console.log("TEST")
     // TODO: Get dashboard_id from newProps
     const dashboard_id = this.props.id
-    axios('/api/dashboards/' + dashboard_id, {
+    axios(window.api_path + '/api/dashboards/' + dashboard_id, {
         method: 'get',
         withCredentials: true
     }).then((response) => {

--- a/pydash-front/src/app/dashboard/Logout.js
+++ b/pydash-front/src/app/dashboard/Logout.js
@@ -27,7 +27,7 @@ class Login extends Component {
         e.preventDefault()
 
         // Make a request for a user with a given ID
-        axios('/api/logout', {
+        axios(window.api_path + '/api/logout', {
             method: 'post',
             withCredentials: true
         }).then((response) => {

--- a/pydash-front/src/app/overview/DashTileGrid.js
+++ b/pydash-front/src/app/overview/DashTileGrid.js
@@ -25,7 +25,7 @@ class DashTileGrid extends Component {
     }
     
     componentDidMount() {
-      axios('/api/dashboards', {
+      axios(window.api_path + '/api/dashboards', {
         method: 'get',
         withCredentials: true
       }).then((response) => {

--- a/pydash-front/src/index.js
+++ b/pydash-front/src/index.js
@@ -4,6 +4,13 @@ import './index.css';
 import App from './App';
 import { BrowserRouter } from 'react-router-dom'
 
+// Make API host path configurable to ensure the application also works well
+// while testing locally on a different port than the back-end application.
+window.api_path = "";
+if(window.location.host === "localhost:3000") {
+    window.api_path = window.location.protocol + "//localhost:5000";
+}
+
 ReactDOM.render((
     <BrowserRouter>
         <App />

--- a/pydash-front/src/login/Auth.js
+++ b/pydash-front/src/login/Auth.js
@@ -6,7 +6,7 @@ class Auth{
     }
 
     doPeek() {
-        return axios('/api/login', {
+        return axios(window.api_path + '/api/login', {
             method: 'post',
             withCredentials: true
         }).then((response) => {

--- a/pydash-front/src/login/Login.js
+++ b/pydash-front/src/login/Login.js
@@ -52,7 +52,7 @@ class Login extends Component {
 
 
         // Make a request for a user with a given ID
-        axios.post('/api/login', {
+        axios.post(window.api_path + '/api/login', {
             username,
             password},
             {withCredentials: true}
@@ -69,11 +69,19 @@ class Login extends Component {
             }));
         }).catch((error) => {
             console.log(error);
-            this.setState(prevState => ({
-                error: true,
-                helperText: 'Incorrect credentials 😱',
-                loading: false,
-            }))
+            if(error.response && error.response.status === 401) {
+                this.setState(prevState => ({
+                    error: true,
+                    helperText: 'Incorrect credentials 😱',
+                    loading: false,
+                }))
+            } else {
+                this.setState(prevState => ({
+                    error: true,
+                    helperText: 'Unknown error returned:' + error,
+                    loading: false,
+                }))
+            }
         });
     }
 


### PR DESCRIPTION
Two crucial front-end fixes: 
- Fixes front-end on different port: Running `yarn start` on `localhost:3000` now correctly connects to Flask on `localhost:5000` again.
- Better error handling while logging in: When Flask returns garbage (or when no connection could be made), this is shown, rather than an incorrect "Incorrect credentials" message.