### PR TITLE
Add exception handling for historic endpoint call fetching

### DIFF
--- a/pydash/flask_monitoring_dashboard_client/__init__.py
+++ b/pydash/flask_monitoring_dashboard_client/__init__.py
@@ -124,7 +124,8 @@ def _decode_jwt(payload, token):
         message = jwt.decode(payload, token, algorithms=['HS256'])
         return json.loads(message['data'])
     except jwt.DecodeError as e:
-        logger.error(f'While decoding: {e}')
+        logger.error(f'While decoding: {e}\n'
+                     f'JWT payload: {payload}')
         raise
     except KeyError:
         logger.error(f'After decoding: JWT-decoded message dict does not contain "data" entry')

--- a/pydash/pydash_app/dashboard/services/seeding.py
+++ b/pydash/pydash_app/dashboard/services/seeding.py
@@ -21,31 +21,6 @@ def seed():
     # Clear current Dashboards-DB.
     repository.clear_all()
 
-    # # Fill in dashboards.
-    # _dev_dashboard_urls = ['http://pydash.io/', 'http://pystach.io/']
-    # _dev_endpoint_calls = [EndpointCall("foo", 0.5, datetime.now(), "0.1", "None", "127.0.0.1"),
-    #                        EndpointCall("foo", 0.1, datetime.now(), "0.1", "None", "127.0.0.2"),
-    #                        EndpointCall("bar", 0.2, datetime.now(), "0.1", "None", "127.0.0.1"),
-    #                        EndpointCall("bar", 0.2, datetime.now() - timedelta(days=1), "0.1", "None", "127.0.0.1"),
-    #                        EndpointCall("bar", 0.2, datetime.now() - timedelta(days=2), "0.1", "None", "127.0.0.1")
-    #                        ]
-    #
-    # # Instead of storing the endpoints in a list, we generate them on the fly,
-    # #  to avoid users sharing the same endpoints for now, as we'd like to have a controlled environment for every user
-    # #  during this stage of development.
-    # for user in user_repository.all():
-    #     for url in _dev_dashboard_urls:
-    #         dashboard = Dashboard(url, user.get_id())
-    #         for endpoint in [Endpoint("foo", True), Endpoint("bar", True)]:
-    #             dashboard.add_endpoint(endpoint)
-    #         for endpoint_call in _dev_endpoint_calls:
-    #             dashboard.add_endpoint_call(endpoint_call)
-    #         print(f'Adding dashboard {dashboard}')
-    #         add(dashboard)
-
-    # TEST
-    # from pydash_app.fetching.fetching import fetch_and_add_endpoints, fetch_and_add_historic_endpoint_calls
-    # for user in [user_repository.find_by_name('W-M'), user_repository.find_by_name('Koen')]:
     for user in user_repository.all():
         dashboard = Dashboard("http://136.243.248.188:9001/dashboard",
                               "cc83733cb0af8b884ff6577086b87909",


### PR DESCRIPTION
In my previous PR #186, I had overlooked the `_fetch_endpoint_calls` exception handling in `fetch_and_add_historic_endpoint_calls`; this PR adds it.

Also closes #135 and #177.