### PR TITLE
Backend/api return state error

### DIFF
--- a/pydash/pydash_web/controller/dashboards.py
+++ b/pydash/pydash_web/controller/dashboards.py
@@ -74,11 +74,16 @@ def _simple_dashboard_detail(dashboard):
         }
     endpoints = [endpoint_dict(endpoint) for endpoint in dashboard.endpoints.values()]
 
-    return {
+    dash_dict = {
         'id': dashboard.id,
         'url': dashboard.url,
         'endpoints': endpoints
     }
+
+    if not dashboard.error:
+        dash_dict['error'] = dashboard.error
+
+    return dash_dict
 
 
 def _dashboard_detail(dashboard):
@@ -96,9 +101,15 @@ def _dashboard_detail(dashboard):
         }
 
     endpoints_dict = [endpoint_dict(endpoint) for endpoint in dashboard.endpoints.values()]
-    return {
+
+    dash_dict = {
         'id': dashboard.id,
         'url': dashboard.url,
         'aggregates': dashboard.aggregated_data(),
         'endpoints': endpoints_dict
     }
+
+    if not dashboard.error:
+        dash_dict['error'] = dashboard.error
+
+    return dash_dict

--- a/pydash/pydash_web/controller/dashboards.py
+++ b/pydash/pydash_web/controller/dashboards.py
@@ -81,9 +81,8 @@ def _simple_dashboard_detail(dashboard):
         'endpoints': endpoints
     }
 
-    for state in DashboardState:
-        if dashboard.state == state and str(state.name).split("_")[-1] == "failure":
-            dash_dict['error'] = dashboard.error
+    if str(dashboard.state.name).split("_")[-1] == "failure":
+        dash_dict['error'] = dashboard.error
 
     return dash_dict
 
@@ -111,8 +110,7 @@ def _dashboard_detail(dashboard):
         'endpoints': endpoints_dict
     }
 
-    for state in DashboardState:
-        if dashboard.state == state and str(state.name).split("_")[-1] == "failure":
-            dash_dict['error'] = dashboard.error
+    if str(dashboard.state.name).split("_")[-1] == "failure":
+        dash_dict['error'] = dashboard.error
 
     return dash_dict

--- a/pydash/pydash_web/controller/dashboards.py
+++ b/pydash/pydash_web/controller/dashboards.py
@@ -6,6 +6,7 @@ Currently only returns static mock data.
 
 from flask import jsonify
 from flask_login import current_user
+from pydash_app.dashboard.dashboard import DashboardState
 
 import pydash_app.dashboard
 import pydash_logger
@@ -80,8 +81,9 @@ def _simple_dashboard_detail(dashboard):
         'endpoints': endpoints
     }
 
-    if not dashboard.error:
-        dash_dict['error'] = dashboard.error
+    for state in DashboardState:
+        if dashboard.state == state and str(state.name).split("_")[-1] == "failure":
+            dash_dict['error'] = dashboard.error
 
     return dash_dict
 
@@ -109,7 +111,8 @@ def _dashboard_detail(dashboard):
         'endpoints': endpoints_dict
     }
 
-    if not dashboard.error:
-        dash_dict['error'] = dashboard.error
+    for state in DashboardState:
+        if dashboard.state == state and str(state.name).split("_")[-1] == "failure":
+            dash_dict['error'] = dashboard.error
 
     return dash_dict


### PR DESCRIPTION
Resolves #188 Note that each future error state should end with `_failure` in order for the error to be properly sent back.