### PR TITLE
Frontend/responsive graphs

### DIFF
--- a/pydash-front/package.json
+++ b/pydash-front/package.json
@@ -15,6 +15,7 @@
     "material-ui-icons": "^1.0.0-beta.36",
     "nivo": "^0.31.0",
     "react": "^16.2.0",
+    "react-container-dimensions": "^1.3.3",
     "react-dom": "^16.2.0",
     "react-router-dom": "^4.2.2",
     "react-vis": "^1.9.2"

--- a/pydash-front/src/authenticated_app/dashboard/statistics_page/DashboardVisitsGraph.js
+++ b/pydash-front/src/authenticated_app/dashboard/statistics_page/DashboardVisitsGraph.js
@@ -18,7 +18,7 @@ class DashboardVisitsGraph extends Component {
             <h4>{this.props.title}</h4>
             <Line
             data={[{id: this.props.tooltip_title, data: this.props.data}]}
-            height={this.props.height - 50}
+            height={this.props.height}
             curve="monotoneX"
             axisBottom={{
                 "orient": "bottom",
@@ -41,7 +41,7 @@ class DashboardVisitsGraph extends Component {
             margin={{
                 "top": 50,
                 "right": 50,
-                "bottom": 70,
+                "bottom": 130,
                 "left": 50
             }}
             colors={["aquamarine", "blue", "cyan"]}

--- a/pydash-front/src/authenticated_app/dashboard/statistics_page/DashboardVisitsGraph.js
+++ b/pydash-front/src/authenticated_app/dashboard/statistics_page/DashboardVisitsGraph.js
@@ -2,53 +2,60 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
 // Contents:
-import { ResponsiveLine } from '@nivo/line'
+import { Line, ResponsiveLine } from '@nivo/line'
 
+// Utils:
+import ResponsiveGraphWrapper from '../../../common/ResponsiveGraphWrapper';
 
 class DashboardVisitsGraph extends Component {
     render() {
-        return (<div style={{width: "100%"}}>
+        let width = this.props.width;
+        if(width < 0 || width === undefined){
+            width = 1;
+        }
+        return (
+            <ResponsiveGraphWrapper height={this.props.height} >
             <h4>{this.props.title}</h4>
-            <ResponsiveLine
-                data={[{id: this.props.tooltip_title, data: this.props.data}]}
-                height={this.props.height ? this.props.height : 300}
-                curve="monotoneX"
-                axisBottom={{
-                    "orient": "bottom",
-                    "tickSize": 5,
-                    "tickPadding": 5,
-                    "tickRotation": 45,
-                    "legend": "date",
-                    "legendOffset": 36,
-                    "legendPosition": "center"
-                }}
-                axisLeft={{
-                    "orient": "left",
-                    "tickSize": 5,
-                    "tickPadding": 5,
-                    "tickRotation": 0,
-                    "legend": "No. pageviews",
-                    "legendOffset": -40,
-                    "legendPosition": "center"
-                }}
-                margin={{
-                    "top": 50,
-                    "right": 50,
-                    "bottom": 50,
-                    "left": 50
-                }}
-                colors={["aquamarine", "blue", "cyan"]}
-                dotSize={10}
-                dotColor="inherit:darker(0.5)"
-                dotBorderWidth={2}
-                dotBorderColor="#ffffff"
-                enableDotLabel={true}
-                dotLabel="y"
-                dotLabelYOffset={-12}
-                animate={true}
-                enableArea={true}
+            <Line
+            data={[{id: this.props.tooltip_title, data: this.props.data}]}
+            height={this.props.height - 50}
+            curve="monotoneX"
+            axisBottom={{
+                "orient": "bottom",
+                "tickSize": 5,
+                "tickPadding": 5,
+                "tickRotation": 45,
+                "legend": "date",
+                "legendOffset": 36,
+                "legendPosition": "center"
+            }}
+            axisLeft={{
+                "orient": "left",
+                "tickSize": 5,
+                "tickPadding": 5,
+                "tickRotation": 0,
+                "legend": "No. pageviews",
+                "legendOffset": -40,
+                "legendPosition": "center"
+            }}
+            margin={{
+                "top": 50,
+                "right": 50,
+                "bottom": 70,
+                "left": 50
+            }}
+            colors={["aquamarine", "blue", "cyan"]}
+            dotSize={10}
+            dotColor="inherit:darker(0.5)"
+            dotBorderWidth={2}
+            dotBorderColor="#ffffff"
+            enableDotLabel={true}
+            dotLabel="y"
+            dotLabelYOffset={-12}
+            animate={true}
+            enableArea={true}
             />
-            </div>
+            </ResponsiveGraphWrapper>
         );
     }
 }
@@ -57,6 +64,7 @@ DashboardVisitsGraph.propTypes = {
     data: PropTypes.array.isRequired,
     title: PropTypes.string.isRequired,
     tooltip_title: PropTypes.string.isRequired,
+    height: PropTypes.number.isRequired,
 };
 
 export default DashboardVisitsGraph;

--- a/pydash-front/src/authenticated_app/dashboard/statistics_page/DashboardVisitsGraph.js
+++ b/pydash-front/src/authenticated_app/dashboard/statistics_page/DashboardVisitsGraph.js
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
 // Contents:
-import { Line, ResponsiveLine } from '@nivo/line'
+import { Line } from '@nivo/line'
 
 // Utils:
 import ResponsiveGraphWrapper from '../../../common/ResponsiveGraphWrapper';

--- a/pydash-front/src/authenticated_app/dashboard/statistics_page/EndpointExecutionTimesPanel.js
+++ b/pydash-front/src/authenticated_app/dashboard/statistics_page/EndpointExecutionTimesPanel.js
@@ -94,12 +94,6 @@ const endpoints = {
 
 };
 
-class WidthShower extends Component {
-    render = () => (
-        <strong>Width: {this.props.width}</strong>
-    );
-}
-
 class EndpointExecutionTimesPanel extends Component {
     constructor(props) {
         super(props);

--- a/pydash-front/src/authenticated_app/dashboard/statistics_page/EndpointExecutionTimesPanel.js
+++ b/pydash-front/src/authenticated_app/dashboard/statistics_page/EndpointExecutionTimesPanel.js
@@ -16,7 +16,8 @@ import ExpansionPanel, {
 
 // Utils:
 import { api_to_bar_data} from "../../../utils";
-import WidthAwareContainer from "../../../common/WidthAwareContainer"
+import WidthAwareContainer from "../../../common/WidthAwareContainer";
+import ContainerDimensions from 'react-container-dimensions';
 
 
 // Dummy data for testing average endpoint execution time visualisation.
@@ -98,7 +99,7 @@ const endpoints = {
 
 class WidthShower extends Component {
     render = () => (
-        <strong>Width: {this.props.containerWidth}</strong>
+        <strong>Width: {this.props.width}</strong>
     );
 }
 
@@ -136,10 +137,9 @@ class EndpointExecutionTimesPanel extends Component {
                 </ExpansionPanelSummary>
                 <ExpansionPanelDetails>
                     {/* <ExecutionTimesGraph data={this.state.average_execution_times} height={this.state.average_execution_times.length*80} title="Average execution time per endpoint" /> */}
-                    <WidthAwareContainer>
-                        <h2> TEST </h2>
+                    <ContainerDimensions>
                         <WidthShower />
-                    </WidthAwareContainer>
+                    </ContainerDimensions>
                 </ExpansionPanelDetails>
             </ExpansionPanel>
         )
@@ -149,6 +149,5 @@ class EndpointExecutionTimesPanel extends Component {
 EndpointExecutionTimesPanel.propTypes = {
     dashboard_id: PropTypes.string.isRequired,
 };
-
 
 export default EndpointExecutionTimesPanel;

--- a/pydash-front/src/authenticated_app/dashboard/statistics_page/EndpointExecutionTimesPanel.js
+++ b/pydash-front/src/authenticated_app/dashboard/statistics_page/EndpointExecutionTimesPanel.js
@@ -16,9 +16,6 @@ import ExpansionPanel, {
 
 // Utils:
 import { api_to_bar_data} from "../../../utils";
-import WidthAwareContainer from "../../../common/WidthAwareContainer";
-import ContainerDimensions from 'react-container-dimensions';
-
 
 // Dummy data for testing average endpoint execution time visualisation.
 const endpoints = {
@@ -136,10 +133,7 @@ class EndpointExecutionTimesPanel extends Component {
                     <h3>Average execution time per endpoint</h3>
                 </ExpansionPanelSummary>
                 <ExpansionPanelDetails>
-                    {/* <ExecutionTimesGraph data={this.state.average_execution_times} height={this.state.average_execution_times.length*80} title="Average execution time per endpoint" /> */}
-                    <ContainerDimensions>
-                        <WidthShower />
-                    </ContainerDimensions>
+                    <ExecutionTimesGraph data={this.state.average_execution_times} height={this.state.average_execution_times.length*80} title="Average execution time per endpoint" />
                 </ExpansionPanelDetails>
             </ExpansionPanel>
         )

--- a/pydash-front/src/authenticated_app/dashboard/statistics_page/EndpointExecutionTimesPanel.js
+++ b/pydash-front/src/authenticated_app/dashboard/statistics_page/EndpointExecutionTimesPanel.js
@@ -16,6 +16,7 @@ import ExpansionPanel, {
 
 // Utils:
 import { api_to_bar_data} from "../../../utils";
+import WidthAwareContainer from "../../../common/WidthAwareContainer"
 
 
 // Dummy data for testing average endpoint execution time visualisation.
@@ -95,6 +96,12 @@ const endpoints = {
 
 };
 
+class WidthShower extends Component {
+    render = () => (
+        <strong>Width: {this.props.containerWidth}</strong>
+    );
+}
+
 class EndpointExecutionTimesPanel extends Component {
     constructor(props) {
         super(props);
@@ -121,13 +128,18 @@ class EndpointExecutionTimesPanel extends Component {
     }
 
     render = () => {
+
         return (
             <ExpansionPanel>
                 <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
                     <h3>Average execution time per endpoint</h3>
                 </ExpansionPanelSummary>
                 <ExpansionPanelDetails>
-                    <ExecutionTimesGraph data={this.state.average_execution_times} height={this.state.average_execution_times.length*80} title="Average execution time per endpoint" />
+                    {/* <ExecutionTimesGraph data={this.state.average_execution_times} height={this.state.average_execution_times.length*80} title="Average execution time per endpoint" /> */}
+                    <WidthAwareContainer>
+                        <h2> TEST </h2>
+                        <WidthShower />
+                    </WidthAwareContainer>
                 </ExpansionPanelDetails>
             </ExpansionPanel>
         )

--- a/pydash-front/src/authenticated_app/dashboard/statistics_page/ExecutionTimesGraph.js
+++ b/pydash-front/src/authenticated_app/dashboard/statistics_page/ExecutionTimesGraph.js
@@ -4,61 +4,52 @@ import PropTypes from 'prop-types';
 // Contents:
 import { Bar } from '@nivo/bar';
 
+// Utils:
+import ResponsiveGraphWrapper from '../../../common/ResponsiveGraphWrapper';
+
 class ExecutionTimesGraph extends Component {
     render() {
-        return (<div style={{width: "100%"}}>
-        <h4>{this.props.title}</h4>
-        <Bar
-            width={1000}
-            height={this.props.height}
-            data={this.props.data}
-            keys={[
-                "average_execution_time",
-            ]}
-            indexBy="name"
-            margin={{
-                "top": 50,
-                "right": 200,
-                "bottom": 50,
-                "left": 120
-            }}
-            padding={0.3}
-            layout="horizontal"
-            colors="nivo"
-            colorBy="id"
-            borderColor="inherit:darker(1.6)"
-            axisBottom={{
-                "orient": "bottom",
-                "tickSize": 5,
-                "tickPadding": 5,
-                "tickRotation": 0,
-            }}
-            axisLeft={{
-                "orient": "left",
-                "tickSize": 5,
-                "tickPadding": 5,
-                "tickRotation": 0,
-            }}
-            labelSkipWidth={12}
-            labelSkipHeight={12}
-            labelTextColor="inherit:darker(1.6)"
-            animate={true}
-            motionStiffness={90}
-            motionDamping={15}
-            legends={[
-                {
-                    "dataFrom": "keys",
-                    "anchor": "bottom-right",
-                    "direction": "column",
-                    "translateX": 120,
-                    "itemWidth": 150,
-                    "itemHeight": 20,
-                    "itemsSpacing": 2,
-                    "symbolSize": 20
-                }
-            ]}
-        />
-        </div>
+        return (
+            <ResponsiveGraphWrapper height={this.props.height}>
+                <h4>{this.props.title}</h4>
+                <Bar
+                    height={this.props.height}
+                    data={this.props.data}
+                    keys={[
+                        "average_execution_time",
+                    ]}
+                    indexBy="name"
+                    margin={{
+                        "top": 50,
+                        "right": 50,
+                        "bottom": 100,
+                        "left": 100
+                    }}
+                    padding={0.3}
+                    layout="horizontal"
+                    colors="nivo"
+                    colorBy="id"
+                    borderColor="inherit:darker(1.6)"
+                    axisBottom={{
+                        "orient": "bottom",
+                        "tickSize": 5,
+                        "tickPadding": 5,
+                        "tickRotation": 0,
+                    }}
+                    axisLeft={{
+                        "orient": "left",
+                        "tickSize": 5,
+                        "tickPadding": 5,
+                        "tickRotation": 0,
+                    }}
+                    labelSkipWidth={12}
+                    labelSkipHeight={12}
+                    labelTextColor="inherit:darker(1.6)"
+                    animate={true}
+                    motionStiffness={90}
+                    motionDamping={15}
+                />
+            </ResponsiveGraphWrapper>
         );
     }
 }

--- a/pydash-front/src/authenticated_app/dashboard/statistics_page/UniqueVisitorsPerDayPanel.js
+++ b/pydash-front/src/authenticated_app/dashboard/statistics_page/UniqueVisitorsPerDayPanel.js
@@ -49,7 +49,7 @@ class UniqueVisitorsPerDayPanel extends Component {
                     <h3>Unique Visitors Per Day</h3>
                 </ExpansionPanelSummary>
                 <ExpansionPanelDetails>
-                    <DashboardVisitsGraph data={this.state.unique_visitors_per_day} title="Unique visitors per day:" tooltip_title="No. visits: "/>
+                    <DashboardVisitsGraph data={this.state.unique_visitors_per_day} title="Unique visitors per day:" tooltip_title="No. visits: " height={400} />
                 </ExpansionPanelDetails>
             </ExpansionPanel>
         )

--- a/pydash-front/src/authenticated_app/dashboard/statistics_page/VisitsPerDayPanel.js
+++ b/pydash-front/src/authenticated_app/dashboard/statistics_page/VisitsPerDayPanel.js
@@ -49,7 +49,7 @@ class VisitsPerDayPanel extends Component {
                     <h3>Visits Per Day</h3>
                 </ExpansionPanelSummary>
                 <ExpansionPanelDetails>
-                    <DashboardVisitsGraph data={this.state.visits_per_day} title="Visits per day:" tooltip_title="No. visits: "/>
+                    <DashboardVisitsGraph data={this.state.visits_per_day} title="Visits per day:" tooltip_title="No. visits: " height={400} />
                 </ExpansionPanelDetails>
             </ExpansionPanel>
         )

--- a/pydash-front/src/common/ResponsiveGraphWrapper.js
+++ b/pydash-front/src/common/ResponsiveGraphWrapper.js
@@ -1,0 +1,34 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import ContainerDimensions from 'react-container-dimensions';
+
+
+class ResponsiveGraphWrapper extends Component {
+    static propTypes = {
+        height: PropTypes.number.isRequired
+    }
+
+    updatedChildren = (width) => {
+        return React.Children.map(
+            this.props.children,
+            (child) => (
+                React.cloneElement(child, { width: width })
+            )
+        );
+    }
+
+    render = () => (
+        <div style={{width: "100%", height: this.props.height, overflow: "hidden"}}>
+            <ContainerDimensions>
+                {({width}) => (
+                    <div style={{position: "absolute", left: 0, right: 0, top: 0, bottom: 0}}>
+                        {this.updatedChildren(width)}
+                    </div>
+                )}
+            </ContainerDimensions>
+        </div>
+    )
+}
+
+export default ResponsiveGraphWrapper;

--- a/pydash-front/src/common/WidthAwareContainer.js
+++ b/pydash-front/src/common/WidthAwareContainer.js
@@ -37,7 +37,7 @@ class WidthAwareContainer extends Component {
             )
         );
         return (
-            <div ref={this.setElement} style={{width: "100%"}}>
+            <div ref={this.setElement} style={{width: "100%", overflow: 'hidden'}}>
                 {updatedChildren}
             </div>
         );

--- a/pydash-front/src/common/WidthAwareContainer.js
+++ b/pydash-front/src/common/WidthAwareContainer.js
@@ -1,0 +1,47 @@
+// This component becomes as large as its container,
+// and then passes its resulting `width` on as the `with` prop to its child,
+// as to make child components that require a width in pixels responsive.
+import React, { Component } from 'react';
+
+class WidthAwareContainer extends Component {
+    state = {
+        width: 0,
+    }
+    dom_element = null;
+
+    setElement = (dom_element) => {
+        this.dom_element = dom_element;
+        this.updateWidth();
+    }
+
+    updateWidth = () => {
+        if(this.dom_element === null){
+            return
+        }
+        this.setState({width: this.dom_element.clientWidth});
+    }
+
+    componentDidMount = () => {
+        window.addEventListener("resize", this.updateWidth);
+    }
+
+    componentWillUnmount = () => {
+        window.removeEventListener("resize", this.updateWidth);
+    }
+
+    render = () => {
+        let updatedChildren = React.Children.map(
+            this.props.children,
+            (child) => (
+                React.cloneElement(child, { containerWidth: this.state.width })
+            )
+        );
+        return (
+            <div ref={this.setElement} style={{width: "100%"}}>
+                {updatedChildren}
+            </div>
+        );
+    }
+}
+
+export default WidthAwareContainer;

--- a/pydash-front/yarn.lock
+++ b/pydash-front/yarn.lock
@@ -1139,6 +1139,10 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+batch-processor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/batch-processor/-/batch-processor-1.0.0.tgz#75c95c32b748e0850d10c2b168f6bdbe9891ace8"
+
 batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
@@ -2402,6 +2406,12 @@ ee-first@1.1.1:
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30:
   version "1.3.41"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.41.tgz#7e33643e00cd85edfd17e04194f6d00e73737235"
+
+element-resize-detector@^1.1.10:
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/element-resize-detector/-/element-resize-detector-1.1.14.tgz#af064a0a618a820ad570a95c5eec5b77be0128c1"
+  dependencies:
+    batch-processor "^1.0.0"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -6047,6 +6057,14 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-container-dimensions@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/react-container-dimensions/-/react-container-dimensions-1.3.3.tgz#5da301e30decb449fb0cef1a2ab210df970ca71e"
+  dependencies:
+    element-resize-detector "^1.1.10"
+    invariant "^2.2.2"
+    prop-types "^15.5.8"
 
 react-dev-utils@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
Fixes #203 : 

- Graph widths are now responsive
- Page+Graphs resizes to smaller width when screen becomes thinner (this was a lot harder than just resizing them when stuff became larger :sweat_smile: )
- Graphs have received a slight update to their sizing so they now look nice on mobile screens as well.