### PR TITLE
Explicitly return None (null) for dashboard name/error

### DIFF
--- a/pydash/pydash_web/controller/dashboards.py
+++ b/pydash/pydash_web/controller/dashboards.py
@@ -80,14 +80,10 @@ def _simple_dashboard_detail(dashboard):
     dashboard_data = {
         'id': dashboard.id,
         'url': dashboard.url,
+        'name': dashboard.name,
+        'error': dashboard.error,
         'endpoints': endpoints
     }
-
-    if dashboard.name is not None:
-        dashboard_data['name'] = dashboard.name
-
-    if str(dashboard.state.name).split("_")[-1] == "failure":
-        dashboard_data['error'] = dashboard.error
 
     return dashboard_data
 
@@ -111,14 +107,10 @@ def _dashboard_detail(dashboard):
     dashboard_data = {
         'id': dashboard.id,
         'url': dashboard.url,
+        'name': dashboard.name,
+        'error': dashboard.error,
         'aggregates': dashboard.aggregated_data(),
         'endpoints': endpoints
     }
-
-    if dashboard.name is not None:
-        dashboard_data['name'] = dashboard.name
-
-    if str(dashboard.state.name).split("_")[-1] == "failure":
-        dashboard_data['error'] = dashboard.error
 
     return dashboard_data


### PR DESCRIPTION
Instead of checking for None around dashboard name/error, we can simply return them since they will be None if not set