### PR TITLE
Fix/build and run

### DIFF
--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -2,7 +2,7 @@
 
 PydashPrint()
 {
-    echo -e "\e[1m\e[92m[PyDash.io]: \e[0m\e[1m$1\e[0m"
+    echo -e '\e[1m\e[92m[PyDash.io]: \e[0m\e[1m$1\e[0m'
 }
 
 BuildFrontend()

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -2,7 +2,7 @@
 
 PydashPrint()
 {
-    echo -e '\e[1m\e[92m[PyDash.io]: \e[0m\e[1m$1\e[0m'
+    echo -e '\e[1m\e[92m[PyDash.io]: \e[0m\e[1m' "$1" '\e[0m'
 }
 
 BuildFrontend()
@@ -27,6 +27,19 @@ BuildBackend()
     PydashPrint "Done!"
 }
 
+SeedBackend()
+{
+    PydashPrint "seeding backend..."
+    cd pydash
+    mkdir -p logs
+    export FLASK_APP=pydash.py
+    export FLASK_ENV=development
+    rm -f ./zeo_filestorage.fs*
+    flask seed
+    cd ..
+    cd ..
+    PydashPrint "Done!"
+}
 
 RunDatabase()
 {
@@ -45,9 +58,57 @@ RunFlask()
     cd ..
 }
 
-BuildFrontend
-BuildBackend
-RunDatabase
-xdg-open "http://localhost:5000" &
-RunFlask
-PydashPrint "Done! Goodbye :-)"
+RunFrontend()
+{
+    cd pydash-front
+    yarn start
+    cd ..
+    PydashPrint "Done!"
+}
+
+RunTests()
+{
+    cd pydash
+    export FLASK_APP=pydash.py
+    export FLASK_ENV=development
+    pipenv run pytest
+    cd ..
+    PydashPrint "Done!"
+}
+
+
+if [ $# -gt 0 ];
+then
+    for i in "$@";
+    do
+        if [ $i == "seed" ];
+        then
+            SeedBackend
+        fi
+        if [ $i == "build" ];
+        then
+            BuildFrontend
+            BuildBackend
+        fi
+        if [ $i == "database" ];
+        then
+            RunDatabase
+        fi
+        if [ $i == "server" ];
+        then
+            xdg-open "http://localhost:5000" &
+            RunFlask
+        fi
+        if [ $i == "frontend" ];
+        then
+            RunFrontend
+        fi
+        if [ $i == "test" ];
+        then
+            RunTests
+        fi
+    done;
+    PydashPrint "Done! Goodbye :-)"
+else
+    ./$0 seed build database server
+fi


### PR DESCRIPTION
- Writes escape codes in a way that zshell (that Patrick uses) also will pick them up.
- Adds support to enter separate keywords of what we want to do:

-`./build_and_run.sh` still has old functionality.
-`./build_and_run.sh server` only runs server
-`./build_and_run.sh database` only runs database
-`./build_and_run.sh database server` runs the database and the server.
-`./build_and_run.sh frontend` will start yarn at localhost:3000 with its auto-recompilation set up
-`./build_and_run.sh build` will only build the project
-`./build_and_run.sh seed` will (re-)seed the database
-`./build_and_run.sh test` runs tests
