### PR TITLE
Correctly update dashboard state after historical fetching

### DIFF
--- a/pydash/pydash_app/dashboard/services/fetching.py
+++ b/pydash/pydash_app/dashboard/services/fetching.py
@@ -330,6 +330,9 @@ def fetch_and_add_historic_endpoint_calls(dashboard):
 
         start_time = end_time
 
+    dashboard.state = DashboardState.initialized_endpoint_calls
+    dashboard.error = None
+
 
 def fetch_and_add_endpoint_calls(dashboard):
     """


### PR DESCRIPTION
Right now the state would be stuck in `DashboardState.initialized_endpoints` (or an error state like `initialize_endpoints_failure`/`initialize_endpoint_calls_failure`), so this PR correctly sets the state and error.