### PR TITLE
Fixes crash when reloading dashboard detail page

### DIFF
--- a/pydash-front/src/authenticated_app/AuthenticatedRoutes.js
+++ b/pydash-front/src/authenticated_app/AuthenticatedRoutes.js
@@ -20,6 +20,9 @@ class AuthenticatedRoutes extends Component {
                     <BreadcrumbRoute exact path={match.url + '/settings'} component={SettingsPage} title='Settings' />
                     <BreadcrumbRoute path={match.url + '/dashboards/'} isLink={false} title='Dashboards' render={ ({ match }) => (
                         <Route path={match.url + '/:id'} render={ ({match}) => {
+                                if(this.props.dashboards === null){
+                                    return (<em>Loading...</em>)
+                                }
                                 const dashboard_info = this.props.dashboards[match.params.id];
                                 return <DashboardRoutes match={match} dashboard={dashboard_info}/>
                         }} />


### PR DESCRIPTION
Ensures that when directly going (entering the URL or refreshing the page) to a dashboard detail page (like `http://localhost:3000/overview/dashboards/a0d9a276-63f9-4ab1-adc2-da0346bc9ee9`), the application will not blow up, since we want these URLs to be bookmarkable/shareable.
