### PR TITLE
Backend/dashboard deletion api

### DIFF
--- a/pydash/pydash_web/api_routes.py
+++ b/pydash/pydash_web/api_routes.py
@@ -20,18 +20,6 @@ def logout():
     return controller.logout()
 
 
-@api.route("/api/dashboards", methods=["GET"])
-@login_required
-def get_dashboards():
-    return controller.dashboards()
-
-
-@api.route("/api/dashboards/<dashboard_id>", methods=["GET"])
-@login_required
-def get_dashboard(dashboard_id):
-    return controller.dashboard(dashboard_id)
-
-
 @api.route("/api/user/register", methods=["POST"])
 def register_user():
     return controller.register_user()
@@ -41,12 +29,6 @@ def register_user():
 @login_required
 def delete_user():
     return controller.delete_user()
-
-
-@api.route("/api/dashboards/register", methods=["POST"])
-@login_required
-def register_dashboard():
-    return controller.register_dashboard()
 
 
 @api.route("/api/user/change_settings", methods=["POST"])
@@ -59,3 +41,27 @@ def change_settings():
 @login_required
 def change_password():
     return controller.change_password()
+
+
+@api.route("/api/dashboards", methods=["GET"])
+@login_required
+def get_dashboards():
+    return controller.dashboards()
+
+
+@api.route("/api/dashboards/<dashboard_id>", methods=["GET"])
+@login_required
+def get_dashboard(dashboard_id):
+    return controller.dashboard(dashboard_id)
+
+
+@api.route("/api/dashboards/register", methods=["POST"])
+@login_required
+def register_dashboard():
+    return controller.register_dashboard()
+
+
+@api.route("/api/dashboards/<dashboard_id>/delete")
+@login_required
+def delete_dashboard(dashboard_id):
+    return controller.delete_dashboard(dashboard_id)

--- a/pydash/pydash_web/api_routes.py
+++ b/pydash/pydash_web/api_routes.py
@@ -70,7 +70,7 @@ def register_dashboard():
     return controller.register_dashboard()
 
 
-@api.route("/api/dashboards/<dashboard_id>/delete")
+@api.route("/api/dashboards/<dashboard_id>/delete", methods=["POST"])
 @login_required
 def delete_dashboard(dashboard_id):
     return controller.delete_dashboard(dashboard_id)

--- a/pydash/pydash_web/controller/__init__.py
+++ b/pydash/pydash_web/controller/__init__.py
@@ -4,10 +4,13 @@ The controller contains one dispatching function per flask_webapp endpoint actio
 
 from .login import login
 from .logout import logout
-from .dashboards import dashboards
-from .dashboards import dashboard
+
 from .register_user import register_user
 from .delete_user import delete_user
-from .register_dashboard import register_dashboard
 from .change_settings import change_settings
 from .change_password import change_password
+
+from .dashboards import dashboards
+from .dashboards import dashboard
+from .register_dashboard import register_dashboard
+from .delete_dashboard import delete_dashboard

--- a/pydash/pydash_web/controller/dashboards.py
+++ b/pydash/pydash_web/controller/dashboards.py
@@ -11,8 +11,6 @@ from pydash_app.dashboard.entity import DashboardState
 import pydash_app.dashboard
 import pydash_logger
 
-# from pydash_app.fetching.dashboard_fetch import update_endpoint_calls, _fetch_endpoint_calls
-
 logger = pydash_logger.Logger(__name__)
 
 

--- a/pydash/pydash_web/controller/dashboards.py
+++ b/pydash/pydash_web/controller/dashboards.py
@@ -6,7 +6,6 @@ Currently only returns static mock data.
 
 from flask import jsonify
 from flask_login import current_user
-from pydash_app.dashboard.entity import DashboardState
 
 import pydash_app.dashboard
 import pydash_logger

--- a/pydash/pydash_web/controller/delete_dashboard.py
+++ b/pydash/pydash_web/controller/delete_dashboard.py
@@ -1,0 +1,7 @@
+"""
+Manages the deletion of a dashboard.
+"""
+
+
+def delete_dashboard(dashboard_id):
+    pass

--- a/pydash/pydash_web/controller/delete_dashboard.py
+++ b/pydash/pydash_web/controller/delete_dashboard.py
@@ -16,21 +16,21 @@ def delete_dashboard(dashboard_id):
         dashboard = pydash_app.dashboard.find(dashboard_id)
     except KeyError:
         logger.warning(f"Could not find dashboard matching with {dashboard_id}")
-        return jsonify({"message": "Could not find a matching dashboard."}), 404
+        return jsonify({"message": "Could not find a matching dashboard"}), 404
     except ValueError:  # Happens when called without a proper UUID
         logger.warning(f"Invalid dashboard_id: {dashboard_id}")
         return jsonify({"message": "Invalid dashboard_id"}), 400
 
     if dashboard.user_id != current_user.id:
         logger.warning(f"{current_user} is not authorised to view {dashboard}")
-        return jsonify({"message": "Not authorised to view this dashboard."}), 403
+        return jsonify({"message": "Not authorised to delete this dashboard"}), 403
 
     try:
         # TODO: only remove if owned by one user, otherwise just remove the user's id from the dashboard
         pydash_app.dashboard.remove_from_repository(dashboard)
     except KeyError:
         logger.warning(f'Dashboard {dashboard} does not seem to exist in the database')
-        jsonify({"message": "Could not find a matching dashboard."}), 404
+        jsonify({"message": "Could not find a matching dashboard"}), 404
 
     result = {'message': 'Successfully removed dashboard'}
     return jsonify(result), 200

--- a/pydash/pydash_web/controller/delete_dashboard.py
+++ b/pydash/pydash_web/controller/delete_dashboard.py
@@ -2,6 +2,35 @@
 Manages the deletion of a dashboard.
 """
 
+from flask import jsonify
+from flask_login import current_user
+
+import pydash_app.dashboard
+import pydash_logger
+
+logger = pydash_logger.Logger(__name__)
+
 
 def delete_dashboard(dashboard_id):
-    pass
+    try:
+        dashboard = pydash_app.dashboard.find(dashboard_id)
+    except KeyError:
+        logger.warning(f"Could not find dashboard matching with {dashboard_id}")
+        return jsonify({"message": "Could not find a matching dashboard."}), 404
+    except ValueError:  # Happens when called without a proper UUID
+        logger.warning(f"Invalid dashboard_id: {dashboard_id}")
+        return jsonify({"message": "Invalid dashboard_id"}), 400
+
+    if dashboard.user_id != current_user.id:
+        logger.warning(f"{current_user} is not authorised to view {dashboard}")
+        return jsonify({"message": "Not authorised to view this dashboard."}), 403
+
+    try:
+        # TODO: only remove if owned by one user, otherwise just remove the user's id from the dashboard
+        pydash_app.dashboard.remove_from_repository(dashboard)
+    except KeyError:
+        logger.warning(f'Dashboard {dashboard} does not seem to exist in the database')
+        jsonify({"message": "Could not find a matching dashboard."}), 404
+
+    result = {'message': 'Successfully removed dashboard'}
+    return jsonify(result), 200


### PR DESCRIPTION
Adds the API route `/api/dashboards/<id>/delete`, which can be used to remove the dashboard (if owned by the current user).

Closes #292.