### PR TITLE
Refactor password requirements

### DIFF
--- a/pydash/pydash_app/user/__init__.py
+++ b/pydash/pydash_app/user/__init__.py
@@ -37,6 +37,9 @@ from . import repository
 from . import verification
 from multi_indexed_collection import DuplicateIndexError
 
+_MINIMUM_PASSWORD_LENGTH1 = 8
+_MINIMUM_PASSWORD_LENGTH2 = 12
+
 
 def add_to_repository(user):
     """
@@ -164,4 +167,18 @@ def verify(verification_code):
     verification.verify(verification_code)
 
 
+def check_password_requirements(password):
+    rules1 = [
+        lambda xs: any(x.isupper() for x in xs),
+        lambda xs: any(not x.isalpha() for x in xs),
+        lambda xs: len(xs) >= _MINIMUM_PASSWORD_LENGTH1
+    ]
+    rules2 = [
+        lambda xs: len(xs) >= _MINIMUM_PASSWORD_LENGTH2
+    ]
+    alternatives = [rules1, rules2]
 
+    def check_rules(rules):
+        return all(rule(password) for rule in rules)
+
+    return any(check_rules(alternative) for alternative in alternatives)

--- a/pydash/pydash_app/user/entity.py
+++ b/pydash/pydash_app/user/entity.py
@@ -7,27 +7,6 @@ import flask_login
 import persistent
 
 
-_MINIMUM_PASSWORD_LENGTH1 = 8
-_MINIMUM_PASSWORD_LENGTH2 = 12
-
-
-def check_password_requirements(password):
-    rules1 = [
-        lambda xs: any(x.isupper() for x in xs),
-        lambda xs: any(not x.isalpha() for x in xs),
-        lambda xs: len(xs) >= _MINIMUM_PASSWORD_LENGTH1
-    ]
-    rules2 = [
-        lambda xs: len(xs) >= _MINIMUM_PASSWORD_LENGTH2
-    ]
-    alternatives = [rules1, rules2]
-
-    def check_rules(rules):
-        return all(rule(password) for rule in rules)
-
-    return any(check_rules(alternative) for alternative in alternatives)
-
-
 class User(persistent.Persistent, flask_login.UserMixin):
     """
     The User entity knows about:
@@ -101,10 +80,6 @@ class User(persistent.Persistent, flask_login.UserMixin):
         self._verification_code = self._smart_verification_code.verification_code
 
     def set_password(self, password):
-
-        if not self._check_password_requirements(password):
-            raise ValueError("Supplied password does not meet requirements")
-
         self.password_hash = generate_password_hash(password)
 
     # Required because `multi_indexed_collection` puts users in a set, that needs to order its keys for fast lookup.

--- a/pydash/pydash_app/user/entity.py
+++ b/pydash/pydash_app/user/entity.py
@@ -12,17 +12,20 @@ _MINIMUM_PASSWORD_LENGTH2 = 12
 
 
 def check_password_requirements(password):
-    rules1 = [lambda xs: any(x.isupper() for x in xs),
-              lambda xs: any(not x.isalpha() for x in xs),
-              lambda xs: len(xs) >= _MINIMUM_PASSWORD_LENGTH1
-              ]
-    rules2 = [lambda xs: len(xs) >= _MINIMUM_PASSWORD_LENGTH2]
+    rules1 = [
+        lambda xs: any(x.isupper() for x in xs),
+        lambda xs: any(not x.isalpha() for x in xs),
+        lambda xs: len(xs) >= _MINIMUM_PASSWORD_LENGTH1
+    ]
+    rules2 = [
+        lambda xs: len(xs) >= _MINIMUM_PASSWORD_LENGTH2
+    ]
     alternatives = [rules1, rules2]
 
-    def func(rules):
+    def check_rules(rules):
         return all(rule(password) for rule in rules)
 
-    return any(func(alternative) for alternative in alternatives)
+    return any(check_rules(alternative) for alternative in alternatives)
 
 
 class User(persistent.Persistent, flask_login.UserMixin):

--- a/pydash/pydash_web/controller/change_password.py
+++ b/pydash/pydash_web/controller/change_password.py
@@ -6,6 +6,7 @@ from flask import jsonify
 from flask_login import current_user
 from flask_restplus.reqparse import RequestParser
 
+import pydash_app.user
 import pydash_app.user.repository as user_repository
 import pydash_logger
 
@@ -30,12 +31,12 @@ def change_password():
         result = {'message': 'Current password incorrect'}
         return jsonify(result), 401
 
-    try:
-        current_user.set_password(new_password)
-    except ValueError:
-        logger.warning("Password change failed - new password invalid")
-        result = {'message': 'New password invalid'}
-        return jsonify(result), 400
+    if not pydash_app.user.check_password_requirements(new_password):
+        logger.warning('Password change failed - password does not conform to the requirements')
+        message = {'message': 'Password change failed - new password does not conform to the requirements'}
+        return jsonify(message), 400
+
+    current_user.set_password(new_password)
 
     user_repository.update(current_user)
 

--- a/pydash/pydash_web/controller/register_user.py
+++ b/pydash/pydash_web/controller/register_user.py
@@ -5,7 +5,6 @@ Manages the registration of a new user.
 from flask import jsonify
 from flask_restplus.reqparse import RequestParser
 from flask_mail import Message
-from pydash_app.user.entity import check_password_requirements
 from pydash_mail import mail
 
 import pydash_app.user
@@ -29,7 +28,7 @@ def register_user():
         logger.warning('User registration failed - username, password or email address missing')
         return jsonify(message), 400
 
-    if not check_password_requirements(password):
+    if not pydash_app.user.check_password_requirements(password):
         message = {'message': 'User registration failed - password does not conform to the requirements.'}
         logger.warning('User registration failed - password does not conform to the requirements.')
         return jsonify(message), 400


### PR DESCRIPTION
This PR slightly refactors the password requirements checking. Current implementation (checking in `User`) would require rewriting a large number of doctests, and also breaks user seeding. This PR moves it to `pydash_app.user` and ensures `pydash_web.controller.register_user` and `pydash_web.controller.change_password` use it correctly.

Closes #362.