### PR TITLE
Remove periodic fetching tasks for deleted dashboards/users

### DIFF
--- a/pydash/pydash_app/dashboard/services/fetching.py
+++ b/pydash/pydash_app/dashboard/services/fetching.py
@@ -76,7 +76,11 @@ def fetch_and_update_new_dashboard_info(dashboard_id):
     """
     Updates the dashboard with the new EndpointCall information that is fetched from the Dashboard's remote location.
     """
-    dashboard = dashboard_repository.find(dashboard_id)
+    try:
+        dashboard = dashboard_repository.find(dashboard_id)
+    except KeyError:
+        logger.warning('Dashboard does not exist')
+        return
 
     logger.info(f'INSIDE FETCH FUNCTION: {dashboard_id}')
 
@@ -94,7 +98,11 @@ def fetch_and_update_historic_dashboard_info(dashboard_id):
     """
     Updates the dashboard with the historic EndpointCall information that is fetched from the Dashboard's remote location.
     """
-    dashboard = dashboard_repository.find(dashboard_id)
+    try:
+        dashboard = dashboard_repository.find(dashboard_id)
+    except KeyError:
+        logger.warning('Dashboard does not exist')
+        return
 
     logger.info(f'INSIDE INITIAL FETCHING FUNCTION: {dashboard_id}')
 

--- a/pydash/pydash_web/controller/delete_dashboard.py
+++ b/pydash/pydash_web/controller/delete_dashboard.py
@@ -3,8 +3,10 @@ Manages the deletion of a dashboard.
 """
 
 from flask import jsonify
-from pydash_app.dashboard import find_verified_dashboard, remove_from_repository
+import uuid
 
+from pydash_app.dashboard import find_verified_dashboard, remove_from_repository
+import periodic_tasks
 import pydash_logger
 
 logger = pydash_logger.Logger(__name__)
@@ -23,6 +25,9 @@ def delete_dashboard(dashboard_id):
     except KeyError:
         logger.warning(f'Dashboard {valid_dashboard} does not seem to exist in the database')
         jsonify({"message": "Could not find a matching dashboard"}), 404
+
+    periodic_tasks.remove_task(('dashboard', valid_dashboard.id, 'historic_fetching'))
+    periodic_tasks.remove_task(('dashboard', valid_dashboard.id, 'fetching'))
 
     result = {'message': 'Successfully removed dashboard'}
     return jsonify(result), 200

--- a/pydash/pydash_web/controller/delete_user.py
+++ b/pydash/pydash_web/controller/delete_user.py
@@ -5,6 +5,7 @@ Manages deletion of a user.
 from flask import jsonify, request
 from flask_login import current_user
 
+import periodic_tasks
 import pydash_app.user as user
 import pydash_app.dashboard as dashboard
 import pydash_logger.logger as pylog
@@ -40,6 +41,9 @@ def delete_user():
     for dash in dashboard.dashboards_of_user(current_user.id):
         try:
             dashboard.remove_from_repository(dash)
+
+            periodic_tasks.remove_task(('dashboard', dash.id, 'historic_fetching'))
+            periodic_tasks.remove_task(('dashboard', dash.id, 'fetching'))
         except KeyError:
             logger.warning(f'Dashboard {dash} from user {current_user} has already been removed.')
 


### PR DESCRIPTION
This PR makes sure that periodic fetching tasks for dashboards are removed when the dashboards/users are removed. It also adds error handling for deleted dashboards in the tasks.