### PR TITLE
Backend/aggregator group

### DIFF
--- a/pydash/pydash_app/dashboard/aggregator/__init__.py
+++ b/pydash/pydash_app/dashboard/aggregator/__init__.py
@@ -74,7 +74,8 @@ class Aggregator(persistent.Persistent):
             return deepcopy(self)
 
         new = Aggregator()
-        new.endpoint_calls = self.endpoint_calls + other.endpoint_calls
+        new.endpoint_calls += self.endpoint_calls
+        new.endpoint_calls += other.endpoint_calls
         for key, _ in new.statistics.items():
             new.statistics[key] = self.statistics[key].add_together(other.statistics[key], self.statistics, other.statistics)
         return new
@@ -91,5 +92,5 @@ class Aggregator(persistent.Persistent):
             return self
         self.endpoint_calls += other.endpoint_calls
         for key, _ in self.statistics.items():
-            self.statistics[key] = self.satatistics[key].add_together(other.statistics[key], self.statistics, other.statistics)
+            self.statistics[key] = self.statistics[key].add_together(other.statistics[key], self.statistics, other.statistics)
         return self

--- a/pydash/pydash_app/dashboard/aggregator/__init__.py
+++ b/pydash/pydash_app/dashboard/aggregator/__init__.py
@@ -111,3 +111,7 @@ class Aggregator(persistent.Persistent):
             new.statistics[key] = self.statistics[key].add_together(other.statistics[key], self.statistics, other.statistics)
         # TODO: if shit goes wrong again w.r.t. missing statistics in output, try to patch in the workaround here as well.
         return new
+
+    def __radd__(self, other):
+        if other == 0:
+            return self.deepcopy()

--- a/pydash/pydash_app/dashboard/aggregator/__init__.py
+++ b/pydash/pydash_app/dashboard/aggregator/__init__.py
@@ -102,3 +102,12 @@ class Aggregator(persistent.Persistent):
         initial_dict['unique_visitors_per_day'] = self._unique_visitors_per_day
 
         return initial_dict
+
+    def __add__(self, other):
+        """Creates a new aggregator object that combines the aggregates of both aggegators."""
+        new = Aggregator()
+        new.endpoint_calls = self.endpoint_calls + other.endpoint_calls
+        for key, _ in new.statistics.items():
+            new.statistics[key] = self.statistics[key].add_together(other.statistics[key], self.statistics, other.statistics)
+        # TODO: if shit goes wrong again w.r.t. missing statistics in output, try to patch in the workaround here as well.
+        return new

--- a/pydash/pydash_app/dashboard/aggregator/aggregator_group.py
+++ b/pydash/pydash_app/dashboard/aggregator/aggregator_group.py
@@ -68,7 +68,7 @@ def remove_duplicate_categories(partition_funs):
 
 
 def calc_endpoint_call_identifier(partition, endpoint_call):
-    return tuple(partition_fun(endpoint_call) for partition_fun in partition)
+    return frozenset(partition_fun(endpoint_call) for partition_fun in partition)
 
 
 def partition_field_names(partition):
@@ -140,7 +140,7 @@ class AggregatorGroup(persistent.Persistent):
         self.partitions = dict()  # frozenset(partitions) -> defaultdict(Aggregator)
         self.partition_names = dict()  # frozenset(partition field names) -> frozenset(partitions)
         for elem in self.partitions_set:
-            self.partitions[elem] = defaultdict(Aggregator)  # tuple(partition field names) -> Aggregator
+            self.partitions[elem] = defaultdict(Aggregator)  # frozenset(partition field names) -> Aggregator
             self.partition_names[frozenset(partition_field_names(elem))] = elem
         for endpoint_call in endpoint_calls:
             self.add_endpoint_call(endpoint_call)
@@ -187,4 +187,4 @@ class AggregatorGroup(persistent.Persistent):
             raise ValueError("Bad input value: input filter type is not supported,"
                              " input filter-value not formatted correctly,"
                              " or multiple input filters of the same type.")
-        return self.partitions[partition][tuple(partition_field_names.values())]
+        return self.partitions[partition][frozenset(partition_field_names.values())]

--- a/pydash/pydash_app/dashboard/aggregator/aggregator_group.py
+++ b/pydash/pydash_app/dashboard/aggregator/aggregator_group.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from itertools import chain, combinations
 import persistent
+from datetime import datetime
 
 from . import Aggregator
 
@@ -188,3 +189,36 @@ class AggregatorGroup(persistent.Persistent):
                              " input filter-value not formatted correctly,"
                              " or multiple input filters of the same type.")
         return self.partitions[partition][frozenset(partition_field_names.values())]
+
+def fetch_aggregator_daterange(filters, date_begin, date_end):
+
+
+
+
+
+def chop_date_range_into_chunks(date_begin, date_end):
+    years = chop_date_range_into_years(date_begin, date_end)
+    weeks = get_weeks_from_beginning_of_year() + get_weeks_until_end_of_year()
+    days = []
+    hours = []
+
+def chop_date_range_into_years(datetime_begin, datetime_end):
+    if datetime_begin > datetime_end:
+        raise ValueError("date_begin cannot be larger than date_end")
+
+    if datetime_begin == datetime(year=datetime_begin.year, month=0, day=0, hour=0):
+        range_begin = datetime_begin.year
+    else:
+        range_begin = datetime_begin.year + 1
+    if datetime_end == datetime(year=datetime_end.year, month=0, day=0, hour=0):
+        range_end = datetime_end.year - 1
+    else:
+        range_end = datetime_end.year
+
+    return [year for year in range(range_begin, range_end)]
+
+def get_weeks_until_end_of_year(datetime_begin):
+    return [week for week in range(datetime_begin, 53)]
+
+def get_weeks_from_beginning_of_year(datetime_end):
+    return [week for week in range(datetime_end)]

--- a/pydash/pydash_app/dashboard/aggregator/statistics.py
+++ b/pydash/pydash_app/dashboard/aggregator/statistics.py
@@ -152,10 +152,10 @@ class AverageExecutionTime(FloatStatisticABC):
 
     def add_together(self, other, dependencies_self, dependencies_other):
         aet = AverageExecutionTime()
-        self_tv = dependencies_self[TotalVisits]
-        other_tv = dependencies_other[TotalVisits]
-        self_tet = dependencies_self[TotalExecutionTime]
-        other_tet = dependencies_other[TotalExecutionTime]
+        self_tv = dependencies_self[TotalVisits].value
+        other_tv = dependencies_other[TotalVisits].value
+        self_tet = dependencies_self[TotalExecutionTime].value
+        other_tet = dependencies_other[TotalExecutionTime].value
 
         if self_tv == 0:
             aet.value = other.value
@@ -314,8 +314,10 @@ class ExecutionTimePercentileABC(FloatStatisticABC):
 
     def add_together(self, other, dependencies_self, dependencies_other):
         etp = self.__class__()
-        etp.value = (dependencies_self[ExecutionTimeTDigest].value + dependencies_other[ExecutionTimeTDigest].value)\
-            .percentile(self.percentile_nr)
+        if other.value != other.empty():
+            etp.value = (dependencies_self[ExecutionTimeTDigest].value +
+                         dependencies_other[ExecutionTimeTDigest].value)\
+                        .percentile(self.percentile_nr)
         return etp
 
 

--- a/pydash/pydash_app/dashboard/aggregator/statistics.py
+++ b/pydash/pydash_app/dashboard/aggregator/statistics.py
@@ -71,6 +71,11 @@ class Statistic(persistent.Persistent, abc.ABC):
             dependency.add_to_collection(collection)
         collection.add(cls)
 
+    @abc.abstractmethod
+    def add_together(self, other, dependencies_self, dependencies_other):
+        """Should return a new statistic where the internals of self and other are added together."""
+        pass
+
 
 class FloatStatisticABC(Statistic):
     """
@@ -100,6 +105,11 @@ class TotalVisits(Statistic):
     def append(self, endpoint_call, dependencies):
         self.value += 1
 
+    def add_together(self, other, dependencies_self, dependencies_other):
+        tv = TotalVisits()
+        tv.value = self.value + other.value
+        return tv
+
 
 class TotalExecutionTime(FloatStatisticABC):
     def should_be_rendered(self):
@@ -113,6 +123,11 @@ class TotalExecutionTime(FloatStatisticABC):
 
     def append(self, endpoint_call, dependencies):
         self.value += endpoint_call.execution_time
+
+    def add_together(self, other, dependencies_self, dependencies_other):
+        te = TotalExecutionTime()
+        te.value = self.value + other.value
+        return te
 
 
 class AverageExecutionTime(FloatStatisticABC):
@@ -135,6 +150,22 @@ class AverageExecutionTime(FloatStatisticABC):
         else:
             self.value = dependencies[TotalExecutionTime].value / dependencies[TotalVisits].value
 
+    def add_together(self, other, dependencies_self, dependencies_other):
+        aet = AverageExecutionTime()
+        self_tv = dependencies_self[TotalVisits]
+        other_tv = dependencies_other[TotalVisits]
+        self_tet = dependencies_self[TotalExecutionTime]
+        other_tet = dependencies_other[TotalExecutionTime]
+
+        if self_tv == 0:
+            aet.value = other.value
+        elif other_tv == 0:
+            aet.value = self.value
+        else:
+            aet.value = (self_tet + other_tet)/(self_tv + other_tv)
+
+        return aet
+
 
 class VisitsPerDay(Statistic):
     def should_be_rendered(self):
@@ -153,6 +184,13 @@ class VisitsPerDay(Statistic):
     def rendered_value(self):
         return date_dict(self.value)
 
+    def add_together(self, other, dependencies_self, dependencies_other):
+        vpd = VisitsPerDay()
+        keyset = set(self.value.keys()).union(set(other.value.keys()))
+        for key in keyset:
+            vpd.value[key] = self.value[key] + other.value[key]
+        return vpd
+
 
 class VisitsPerIP(Statistic):
     def should_be_rendered(self):
@@ -169,6 +207,13 @@ class VisitsPerIP(Statistic):
 
     def rendered_value(self):
         return dict(self.value)
+
+    def add_together(self, other, dependencies_self, dependencies_other):
+        vpd = VisitsPerDay()
+        keyset = set(self.value.keys()).union(set(other.value.keys()))
+        for key in keyset:
+            vpd.value[key] = self.value[key] + other.value[key]
+        return vpd
 
 
 class UniqueVisitorsAllTime(Statistic):
@@ -187,6 +232,11 @@ class UniqueVisitorsAllTime(Statistic):
     def rendered_value(self):
         return len(self.value)
 
+    def add_together(self, other, dependencies_self, dependencies_other):
+        uvat = UniqueVisitorsAllTime()
+        uvat.value = self.value.union(other.value)
+        return uvat
+
 
 class UniqueVisitorsPerDay(Statistic):
     def should_be_rendered(self):
@@ -204,6 +254,13 @@ class UniqueVisitorsPerDay(Statistic):
 
     def rendered_value(self):
         return date_dict({k: len(v) for k, v in self.value.items()})
+
+    def add_together(self, other, dependencies_self, dependencies_other):
+        uvpd = UniqueVisitorsPerDay()
+        keyset = set(self.value.keys()).union(set(other.value.keys()))
+        for key in keyset:
+            uvpd.value[key] = self.value[key].union(other.value[key])
+        return uvpd
 
 
 class ExecutionTimeTDigest(Statistic):
@@ -226,6 +283,11 @@ class ExecutionTimeTDigest(Statistic):
     def append(self, endpoint_call, dependencies):
         self.value.update(endpoint_call.execution_time)
 
+    def add_together(self, other, dependencies_self, dependencies_other):
+        ettd = ExecutionTimeTDigest()
+        ettd.value = self.value + other.value
+        return ettd
+
 
 class ExecutionTimePercentileABC(FloatStatisticABC):
     """Abstract base class for execution time percentile statistics."""
@@ -236,64 +298,78 @@ class ExecutionTimePercentileABC(FloatStatisticABC):
         super().__init__()
         self.value = self.empty()
 
+    @property
+    @abc.abstractmethod
+    def percentile_nr(self):
+        pass
+
     def should_be_rendered(self):
         return True
 
     def empty(self):
         return ExecutionTimePercentileABC._NoDataErrorValue
 
+    def append(self, endpoint_call, dependencies):
+        self.value = dependencies[ExecutionTimeTDigest].value.percentile(self.percentile_nr)
+
+    def add_together(self, other, dependencies_self, dependencies_other):
+        etp = self.__class__()
+        etp.value = (dependencies_self[ExecutionTimeTDigest].value + dependencies_other[ExecutionTimeTDigest].value)\
+            .percentile(self.percentile_nr)
+        return etp
+
 
 class FastestExecutionTime(ExecutionTimePercentileABC):
     def field_name(self):
         return 'fastest_measured_execution_time'
 
-    def append(self, endpoint_call, dependencies):
-        self.value = dependencies[ExecutionTimeTDigest].value.percentile(0)
+    def percentile_nr(self):
+        return 0
 
 
 class FastestQuartileExecutionTime(ExecutionTimePercentileABC):
     def field_name(self):
         return 'fastest_quartile_execution_time'
 
-    def append(self, endpoint_call, dependencies):
-        self.value = dependencies[ExecutionTimeTDigest].value.percentile(25)
+    def percentile_nr(self):
+        return 25
 
 
 class MedianExecutionTime(ExecutionTimePercentileABC):
     def field_name(self):
         return 'median_execution_time'
 
-    def append(self, endpoint_call, dependencies):
-        self.value = dependencies[ExecutionTimeTDigest].value.percentile(50)
+    def percentile_nr(self):
+        return 50
 
 
 class SlowestQuartileExecutionTime(ExecutionTimePercentileABC):
     def field_name(self):
         return 'slowest_quartile_execution_time'
 
-    def append(self, endpoint_call, dependencies):
-        self.value = dependencies[ExecutionTimeTDigest].value.percentile(75)
+    def percentile_nr(self):
+        return 75
 
 
 class NinetiethPercentileExecutionTime(ExecutionTimePercentileABC):
     def field_name(self):
         return 'ninetieth_percentile_execution_time'
 
-    def append(self, endpoint_call, dependencies):
-        self.value = dependencies[ExecutionTimeTDigest].value.percentile(90)
+    def percentile_nr(self):
+        return 90
 
 
 class NinetyNinthPercentileExecutionTime(ExecutionTimePercentileABC):
     def field_name(self):
         return 'ninety-ninth_percentile_execution_time'
 
-    def append(self, endpoint_call, dependencies):
-        self.value = dependencies[ExecutionTimeTDigest].value.percentile(99)
+    def percentile_nr(self):
+        return 99
 
 
 class SlowestExecutionTime(ExecutionTimePercentileABC):
     def field_name(self):
         return 'slowest_measured_execution_time'
 
-    def append(self, endpoint_call, dependencies):
-        self.value = dependencies[ExecutionTimeTDigest].value.percentile(100)
+    def percentile_nr(self):
+        return 100

--- a/pydash/pydash_app/dashboard/aggregator/temporal_aggregator_group.py
+++ b/pydash/pydash_app/dashboard/aggregator/temporal_aggregator_group.py
@@ -1,6 +1,0 @@
-import persistent
-
-
-class TemporalAggregatorGroup(persistent.Persistent):
-
-    pass

--- a/pydash/pydash_app/dashboard/aggregator/temporal_aggregator_group.py
+++ b/pydash/pydash_app/dashboard/aggregator/temporal_aggregator_group.py
@@ -1,0 +1,6 @@
+import persistent
+
+
+class TemporalAggregatorGroup(persistent.Persistent):
+
+    pass


### PR DESCRIPTION
This PR adds the `fetch_aggregator_daterange` method to `AggregatorGroup`.
This method requires you to specify a `start_datetime` and `end_datetime`, where the range of dates would be [`start_datetime`, `end_datetime`), such that the returned Aggregator object contains the aggregated values of all aggregators/endpoint-calls within that datetime range.

The method will be precise up to the minute in the sense that it disregards all data from seconds and downwards in terms of precision. (e.g. `datetime(year=1, month=2, day=3, hour=4, minute=5, second=6, etc.)` is regarded to be the same as `datetime(year=1, month=2, day=3, hour=4, minute=5, second=0, etc.)` ) 