### PR TITLE
Backend/refactor statistic per timeslice

### DIFF
--- a/pydash/pydash_app/dashboard/aggregator/__init__.py
+++ b/pydash/pydash_app/dashboard/aggregator/__init__.py
@@ -27,6 +27,7 @@ class Aggregator(persistent.Persistent):
         statistics.NinetiethPercentileExecutionTime,
         statistics.NinetyNinthPercentileExecutionTime,
         statistics.SlowestExecutionTime,
+        # statistics.Versions,
     ])
     statistics_classes_with_dependencies = OrderedSet()
     for statistic in contained_statistics_classes:
@@ -88,9 +89,10 @@ class Aggregator(persistent.Persistent):
             return self.__add__(other)
 
     def __iadd__(self, other):
+
         if other is None:
             return self
         self.endpoint_calls += other.endpoint_calls
-        for key, _ in self.statistics.items():
+        for key in self.statistics.keys():
             self.statistics[key] = self.statistics[key].add_together(other.statistics[key], self.statistics, other.statistics)
         return self

--- a/pydash/pydash_app/dashboard/aggregator/__init__.py
+++ b/pydash/pydash_app/dashboard/aggregator/__init__.py
@@ -16,10 +16,10 @@ class Aggregator(persistent.Persistent):
     contained_statistics_classes = OrderedSet([
         statistics.TotalVisits,
         statistics.AverageExecutionTime,
-        statistics.VisitsPerDay,
+        # statistics.VisitsPerDay,
         statistics.VisitsPerIP,
         statistics.UniqueVisitorsAllTime,
-        statistics.UniqueVisitorsPerDay,
+        # statistics.UniqueVisitorsPerDay,
         statistics.FastestExecutionTime,
         statistics.FastestQuartileExecutionTime,
         statistics.MedianExecutionTime,

--- a/pydash/pydash_app/dashboard/aggregator/aggregator_group.py
+++ b/pydash/pydash_app/dashboard/aggregator/aggregator_group.py
@@ -194,7 +194,7 @@ class AggregatorGroup(persistent.Persistent):
             aggregator_dict[endpoint_call_identifier].add_endpoint_call(endpoint_call)
         self._p_changed = True # ZODB mark object as changed
 
-    def fetch_aggregator(self, filter_dict):
+    def fetch_aggregator(self, filter_dict={}):
         """
         Filters the internal collection of aggregators and returns the right one depending on filter_dict.
         :param filter_dict: A dictionary containing property_name-value pairs to filter on.

--- a/pydash/pydash_app/dashboard/aggregator/statistics.py
+++ b/pydash/pydash_app/dashboard/aggregator/statistics.py
@@ -55,7 +55,7 @@ class Statistic(persistent.Persistent, abc.ABC):
 
     def append(self, endpoint_call, dependencies):
         self.perform_append(endpoint_call, dependencies)
-        self._p_changed = True # ZODB mark object as changed
+        self._p_changed = True  # ZODB mark object as changed
 
     @abc.abstractmethod
     def perform_append(self, endpoint_call, dependencies):
@@ -387,3 +387,25 @@ class SlowestExecutionTime(ExecutionTimePercentileABC):
 
     def percentile_nr(self):
         return 100
+
+
+# class Versions(Statistic):
+#     def should_be_rendered(self):
+#         return True
+#
+#     def empty(self):
+#         return set()
+#
+#     def field_name(self):
+#         return 'versions'
+#
+#     def rendered_value(self):
+#         return list(self.value)
+#
+#     def perform_append(self, endpoint_call, dependencies):
+#         self.value.add(endpoint_call.version)
+#
+#     def add_together(self, other, dependencies_self, dependencies_other):
+#         versions = Versions()
+#         versions.value = self.value.union(other.value)
+#         return versions

--- a/pydash/pydash_app/dashboard/aggregator/statistics.py
+++ b/pydash/pydash_app/dashboard/aggregator/statistics.py
@@ -61,8 +61,9 @@ class Statistic(persistent.Persistent, abc.ABC):
     def perform_append(self, endpoint_call, dependencies):
         pass
 
+    @classmethod
     @abc.abstractmethod
-    def field_name(self):
+    def field_name(cls):
         pass
 
     def rendered_value(self):
@@ -171,29 +172,29 @@ class AverageExecutionTime(FloatStatisticABC):
         return aet
 
 
-class VisitsPerDay(Statistic):
-    def should_be_rendered(self):
-        return True
-
-    def empty(self):
-        return defaultdict(int)
-
-    def field_name(self):
-        return 'visits_per_day'
-
-    def perform_append(self, endpoint_call, dependencies):
-        date = endpoint_call.time.date()
-        self.value[date] += 1
-
-    def rendered_value(self):
-        return date_dict(self.value)
-
-    def add_together(self, other, dependencies_self, dependencies_other):
-        vpd = VisitsPerDay()
-        keyset = set(self.value.keys()).union(set(other.value.keys()))
-        for key in keyset:
-            vpd.value[key] = self.value[key] + other.value[key]
-        return vpd
+# class VisitsPerDay(Statistic):
+#     def should_be_rendered(self):
+#         return True
+#
+#     def empty(self):
+#         return defaultdict(int)
+#
+#     def field_name(self):
+#         return 'visits_per_day'
+#
+#     def perform_append(self, endpoint_call, dependencies):
+#         date = endpoint_call.time.date()
+#         self.value[date] += 1
+#
+#     def rendered_value(self):
+#         return date_dict(self.value)
+#
+#     def add_together(self, other, dependencies_self, dependencies_other):
+#         vpd = VisitsPerDay()
+#         keyset = set(self.value.keys()).union(set(other.value.keys()))
+#         for key in keyset:
+#             vpd.value[key] = self.value[key] + other.value[key]
+#         return vpd
 
 
 class VisitsPerIP(Statistic):
@@ -242,29 +243,29 @@ class UniqueVisitorsAllTime(Statistic):
         return uvat
 
 
-class UniqueVisitorsPerDay(Statistic):
-    def should_be_rendered(self):
-        return True
-
-    def empty(self):
-        return defaultdict(set)
-
-    def field_name(self):
-        return 'unique_visitors_per_day'
-
-    def perform_append(self, endpoint_call, dependencies):
-        date = endpoint_call.time.date()
-        self.value[date].add(endpoint_call.ip)
-
-    def rendered_value(self):
-        return date_dict({k: len(v) for k, v in self.value.items()})
-
-    def add_together(self, other, dependencies_self, dependencies_other):
-        uvpd = UniqueVisitorsPerDay()
-        keyset = set(self.value.keys()).union(set(other.value.keys()))
-        for key in keyset:
-            uvpd.value[key] = self.value[key].union(other.value[key])
-        return uvpd
+# class UniqueVisitorsPerDay(Statistic):
+#     def should_be_rendered(self):
+#         return True
+#
+#     def empty(self):
+#         return defaultdict(set)
+#
+#     def field_name(self):
+#         return 'unique_visitors_per_day'
+#
+#     def perform_append(self, endpoint_call, dependencies):
+#         date = endpoint_call.time.date()
+#         self.value[date].add(endpoint_call.ip)
+#
+#     def rendered_value(self):
+#         return date_dict({k: len(v) for k, v in self.value.items()})
+#
+#     def add_together(self, other, dependencies_self, dependencies_other):
+#         uvpd = UniqueVisitorsPerDay()
+#         keyset = set(self.value.keys()).union(set(other.value.keys()))
+#         for key in keyset:
+#             uvpd.value[key] = self.value[key].union(other.value[key])
+#         return uvpd
 
 
 class ExecutionTimeTDigest(Statistic):

--- a/pydash/pydash_app/dashboard/endpoint.py
+++ b/pydash/pydash_app/dashboard/endpoint.py
@@ -73,10 +73,20 @@ class Endpoint(persistent.Persistent):
         return self._aggregator_group.fetch_aggregator_inclusive_daterange({}, start_date, end_date,
                                                                            granularity).as_dict()
 
-    def statistic_per_timeslice(self, statistic, timeslice, start_datetime, end_datetime):
+    def statistic(self, statistic, filters):
         """
 
         :param statistic:
+        :param filters:
+        :return:
+        """
+        return self._aggregator_group.fetch_aggregator(filters).as_dict()[statistic]
+
+    def statistic_per_timeslice(self, statistic, filters, timeslice, start_datetime, end_datetime):
+        """
+
+        :param statistic:
+        :param filters: A dict containing filter_name-filter_value pairs to filter on. May not contain time-based filters.
         :param timeslice:
         :param start_datetime:
         :param end_datetime:
@@ -84,9 +94,9 @@ class Endpoint(persistent.Persistent):
              and the corresponding statistic, over the specified datetime range.
         """
         return_dict = {}
-        for datetime, aggregator in self._aggregator_group.fetch_aggregators_per_timeslice({}, timeslice,
+        for datetime, aggregator in self._aggregator_group.fetch_aggregators_per_timeslice(filters, timeslice,
                                                                                            start_datetime,
-                                                                                           end_datetime):
+                                                                                           end_datetime).items():
             return_dict[datetime] = aggregator.as_dict()[statistic]
 
         return return_dict

--- a/pydash/pydash_app/dashboard/endpoint.py
+++ b/pydash/pydash_app/dashboard/endpoint.py
@@ -61,3 +61,32 @@ class Endpoint(persistent.Persistent):
         :return: A dict containing aggregated data points.
         """
         return self._aggregator_group.fetch_aggregator({}).as_dict()
+
+    def aggregated_data_daterange(self, start_date, end_date, granularity):
+        """
+        Returns the aggregated data on this dashboard over the specified daterange.
+        :param start_date: A datetime object that is treated as the inclusive lower bound of the daterange.
+        :param end_date: A datetime object that is treated as the inclusive upper bound of the daterange.
+        :param granularity: A string denoting the granularity of the daterange.
+        :return: A dictionary with all aggregated statistics and their values.
+        """
+        return self._aggregator_group.fetch_aggregator_inclusive_daterange({}, start_date, end_date,
+                                                                           granularity).as_dict()
+
+    def statistic_per_timeslice(self, statistic, timeslice, start_datetime, end_datetime):
+        """
+
+        :param statistic:
+        :param timeslice:
+        :param start_datetime:
+        :param end_datetime:
+        :return: A dictionary consisting of a datetime string (key)(formatted according to the ISO-8601 standard)
+             and the corresponding statistic, over the specified datetime range.
+        """
+        return_dict = {}
+        for datetime, aggregator in self._aggregator_group.fetch_aggregators_per_timeslice({}, timeslice,
+                                                                                           start_datetime,
+                                                                                           end_datetime):
+            return_dict[datetime] = aggregator.as_dict()[statistic]
+
+        return return_dict

--- a/pydash/pydash_app/dashboard/entity.py
+++ b/pydash/pydash_app/dashboard/entity.py
@@ -25,11 +25,10 @@ Involved usage example:
 >>> d.add_endpoint_call(ec4)
 >>> d.add_endpoint_call(ec5)
 >>> d.aggregated_data()
-{'total_visits': 5, 'total_execution_time': 1.2, 'average_execution_time': 0.24, 'visits_per_day': {'2018-04-25': 3, '2018-04-24': 1, '2018-04-23': 1}, 'visits_per_ip': {'127.0.0.1': 4, '127.0.0.2': 1}, 'unique_visitors': 2, 'unique_visitors_per_day': {'2018-04-25': 2, '2018-04-24': 1, '2018-04-23': 1}, 'fastest_measured_execution_time': 0.1, 'fastest_quartile_execution_time': 0.14, 'median_execution_time': 0.2, 'slowest_quartile_execution_time': 0.39, 'ninetieth_percentile_execution_time': 0.5, 'ninety-ninth_percentile_execution_time': 0.5, 'slowest_measured_execution_time': 0.5}
+{'total_visits': 5, 'total_execution_time': 1.2, 'average_execution_time': 0.24, 'visits_per_ip': {'127.0.0.1': 4, '127.0.0.2': 1}, 'unique_visitors': 2, 'fastest_measured_execution_time': 0.1, 'fastest_quartile_execution_time': 0.14, 'median_execution_time': 0.2, 'slowest_quartile_execution_time': 0.39, 'ninetieth_percentile_execution_time': 0.5, 'ninety-ninth_percentile_execution_time': 0.5, 'slowest_measured_execution_time': 0.5}
 >>> d.endpoints['foo'].aggregated_data()
-{'total_visits': 2, 'total_execution_time': 0.6, 'average_execution_time': 0.3, 'visits_per_day': {'2018-04-25': 2}, 'visits_per_ip': {'127.0.0.1': 1, '127.0.0.2': 1}, 'unique_visitors': 2, 'unique_visitors_per_day': {'2018-04-25': 2}, 'fastest_measured_execution_time': 0.1, 'fastest_quartile_execution_time': 0.1, 'median_execution_time': 0.3, 'slowest_quartile_execution_time': 0.5, 'ninetieth_percentile_execution_time': 0.5, 'ninety-ninth_percentile_execution_time': 0.5, 'slowest_measured_execution_time': 0.5}
+{'total_visits': 2, 'total_execution_time': 0.6, 'average_execution_time': 0.3, 'visits_per_ip': {'127.0.0.1': 1, '127.0.0.2': 1}, 'unique_visitors': 2, 'fastest_measured_execution_time': 0.1, 'fastest_quartile_execution_time': 0.1, 'median_execution_time': 0.3, 'slowest_quartile_execution_time': 0.5, 'ninetieth_percentile_execution_time': 0.5, 'ninety-ninth_percentile_execution_time': 0.5, 'slowest_measured_execution_time': 0.5}
 >>> d.endpoints['bar'].aggregated_data()
-{'total_visits': 3, 'total_execution_time': 0.6, 'average_execution_time': 0.2, 'visits_per_day': {'2018-04-25': 1, '2018-04-24': 1, '2018-04-23': 1}, 'visits_per_ip': {'127.0.0.1': 3}, 'unique_visitors': 1, 'unique_visitors_per_day': {'2018-04-25': 1, '2018-04-24': 1, '2018-04-23': 1}, 'fastest_measured_execution_time': 0.2, 'fastest_quartile_execution_time': 0.2, 'median_execution_time': 0.2, 'slowest_quartile_execution_time': 0.2, 'ninetieth_percentile_execution_time': 0.2, 'ninety-ninth_percentile_execution_time': 0.2, 'slowest_measured_execution_time': 0.2}
 
 """
 

--- a/pydash/pydash_app/dashboard/entity.py
+++ b/pydash/pydash_app/dashboard/entity.py
@@ -29,6 +29,7 @@ Involved usage example:
 >>> d.endpoints['foo'].aggregated_data()
 {'total_visits': 2, 'total_execution_time': 0.6, 'average_execution_time': 0.3, 'visits_per_ip': {'127.0.0.1': 1, '127.0.0.2': 1}, 'unique_visitors': 2, 'fastest_measured_execution_time': 0.1, 'fastest_quartile_execution_time': 0.1, 'median_execution_time': 0.3, 'slowest_quartile_execution_time': 0.5, 'ninetieth_percentile_execution_time': 0.5, 'ninety-ninth_percentile_execution_time': 0.5, 'slowest_measured_execution_time': 0.5}
 >>> d.endpoints['bar'].aggregated_data()
+{'total_visits': 3, 'total_execution_time': 0.6, 'average_execution_time': 0.2, 'visits_per_ip': {'127.0.0.1': 3}, 'unique_visitors': 1, 'fastest_measured_execution_time': 0.2, 'fastest_quartile_execution_time': 0.2, 'median_execution_time': 0.2, 'slowest_quartile_execution_time': 0.2, 'ninetieth_percentile_execution_time': 0.2, 'ninety-ninth_percentile_execution_time': 0.2, 'slowest_measured_execution_time': 0.2}
 
 """
 

--- a/pydash/pydash_app/dashboard/entity.py
+++ b/pydash/pydash_app/dashboard/entity.py
@@ -166,6 +166,22 @@ class Dashboard(persistent.Persistent):
         """
         return self._aggregator_group.fetch_aggregator_inclusive_daterange({}, start_date, end_date, granularity).as_dict()
 
+    def statistic_per_timeslice(self, statistic, timeslice, start_datetime, end_datetime):
+        """
+
+        :param statistic:
+        :param timeslice:
+        :param start_datetime:
+        :param end_datetime:
+        :return: A dictionary consisting of a datetime string (key)(formatted according to the ISO-8601 standard)
+             and the corresponding statistic, over the specified datetime range.
+        """
+        return_dict = {}
+        for datetime, aggregator in self._aggregator_group.fetch_aggregators_per_timeslice({}, timeslice, start_datetime, end_datetime).items():
+            return_dict[datetime] = aggregator.as_dict()[statistic]
+
+        return return_dict
+
     def first_endpoint_call_time(self):
         if not self._endpoint_calls:
             return None


### PR DESCRIPTION
Refactors some of the statistics and aggregator methods, such that they are more generically accessible. Added a `statistic` method as well, such that direct access to statistics is possible (now that I think about it, the current methods that return aggregators should probably return statistics when asked for them. I might add that to this or a new PR later.)

Please do not mind the commented out code regarding versions, as when I started working on #413 , I forgot to change branches. This will be cleaned up in the PR for that issue.