### PR TITLE
Removed unnecessary statistics.

### DIFF
--- a/pydash/pydash_app/dashboard/aggregator/__init__.py
+++ b/pydash/pydash_app/dashboard/aggregator/__init__.py
@@ -16,10 +16,8 @@ class Aggregator(persistent.Persistent):
     contained_statistics_classes = OrderedSet([
         statistics.TotalVisits,
         statistics.AverageExecutionTime,
-        # statistics.VisitsPerDay,
         statistics.VisitsPerIP,
         statistics.UniqueVisitorsAllTime,
-        # statistics.UniqueVisitorsPerDay,
         statistics.FastestExecutionTime,
         statistics.FastestQuartileExecutionTime,
         statistics.MedianExecutionTime,

--- a/pydash/pydash_app/dashboard/aggregator/statistics.py
+++ b/pydash/pydash_app/dashboard/aggregator/statistics.py
@@ -172,31 +172,6 @@ class AverageExecutionTime(FloatStatisticABC):
         return aet
 
 
-# class VisitsPerDay(Statistic):
-#     def should_be_rendered(self):
-#         return True
-#
-#     def empty(self):
-#         return defaultdict(int)
-#
-#     def field_name(self):
-#         return 'visits_per_day'
-#
-#     def perform_append(self, endpoint_call, dependencies):
-#         date = endpoint_call.time.date()
-#         self.value[date] += 1
-#
-#     def rendered_value(self):
-#         return date_dict(self.value)
-#
-#     def add_together(self, other, dependencies_self, dependencies_other):
-#         vpd = VisitsPerDay()
-#         keyset = set(self.value.keys()).union(set(other.value.keys()))
-#         for key in keyset:
-#             vpd.value[key] = self.value[key] + other.value[key]
-#         return vpd
-
-
 class VisitsPerIP(Statistic):
     def should_be_rendered(self):
         return True
@@ -241,31 +216,6 @@ class UniqueVisitorsAllTime(Statistic):
         uvat = UniqueVisitorsAllTime()
         uvat.value = self.value.union(other.value)
         return uvat
-
-
-# class UniqueVisitorsPerDay(Statistic):
-#     def should_be_rendered(self):
-#         return True
-#
-#     def empty(self):
-#         return defaultdict(set)
-#
-#     def field_name(self):
-#         return 'unique_visitors_per_day'
-#
-#     def perform_append(self, endpoint_call, dependencies):
-#         date = endpoint_call.time.date()
-#         self.value[date].add(endpoint_call.ip)
-#
-#     def rendered_value(self):
-#         return date_dict({k: len(v) for k, v in self.value.items()})
-#
-#     def add_together(self, other, dependencies_self, dependencies_other):
-#         uvpd = UniqueVisitorsPerDay()
-#         keyset = set(self.value.keys()).union(set(other.value.keys()))
-#         for key in keyset:
-#             uvpd.value[key] = self.value[key].union(other.value[key])
-#         return uvpd
 
 
 class ExecutionTimeTDigest(Statistic):


### PR DESCRIPTION
Removes unnecessary `<statistic> per <timeslice>` statistics, as we have methods that can do this fairly easily. (As well as the fact that Aggregators may operate on different sizes of timeslices, without knowing that themselves [e.g. one day, or one year], which makes it impossible to uniformly implement such generic statistics in this manner.